### PR TITLE
devices, mqtt, websocket connections

### DIFF
--- a/lib/components/devices/cards/sensor_node_card.dart
+++ b/lib/components/devices/cards/sensor_node_card.dart
@@ -18,15 +18,16 @@ import '../../../subcomponents/devices/device_dialog.dart';
 import 'package:smmic/utils/logs.dart';
 
 class SensorNodeCard extends StatefulWidget {
-  const SensorNodeCard({super.key, required this.deviceInfo});
+  const SensorNodeCard({super.key, required this.deviceInfo, required this.deviceSnapshot});
 
   final SensorNode deviceInfo;
+  final SensorNodeSnapshot? deviceSnapshot;
 
   @override
   State<SensorNodeCard> createState() => _SensorNodeCardState();
 }
 
-class _SensorNodeCardState extends State<SensorNodeCard> with AutomaticKeepAliveClientMixin {
+class _SensorNodeCardState extends State<SensorNodeCard> {
 
   final ApiRequest _apiRequest = ApiRequest();
   final ApiRoutes _apiRoutes = ApiRoutes();
@@ -53,7 +54,6 @@ class _SensorNodeCardState extends State<SensorNodeCard> with AutomaticKeepAlive
   @override
   void initState(){
     super.initState();
-    context.read<DevicesProvider>().deviceReadings(widget.deviceInfo.deviceID);
   }
 
   @override
@@ -68,7 +68,7 @@ class _SensorNodeCardState extends State<SensorNodeCard> with AutomaticKeepAlive
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
+    final SensorNodeSnapshot deviceSnapshot = widget.deviceSnapshot ?? SensorNodeSnapshot.placeHolder(deviceId: widget.deviceInfo.deviceID);
 
     final DeviceDialog _skDeviceDialog = DeviceDialog(
         context: context,
@@ -76,17 +76,6 @@ class _SensorNodeCardState extends State<SensorNodeCard> with AutomaticKeepAlive
         latitude: widget.deviceInfo.latitude,
         longitude: widget.deviceInfo.longitude
     );
-
-    List<SensorNodeSnapshot?> senSnapshotList = context.watch<DevicesProvider>().sensorNodeSnapshotList;
-    SensorNodeSnapshot? sensorNodeSnapshot;
-
-    if (senSnapshotList.isNotEmpty) {
-      List<SensorNodeSnapshot?> itemSearchResult = senSnapshotList.where((item) => item?.deviceID == widget.deviceInfo.deviceID).toList();
-      if (itemSearchResult.isNotEmpty) {
-        sensorNodeSnapshot = itemSearchResult.first;
-      }
-    }
-    sensorNodeSnapshot = sensorNodeSnapshot ?? SensorNodeSnapshot.placeHolder(deviceId: widget.deviceInfo.deviceID);
 
     return GestureDetector(
       onTap: () =>
@@ -147,13 +136,11 @@ class _SensorNodeCardState extends State<SensorNodeCard> with AutomaticKeepAlive
                               mainAxisAlignment: MainAxisAlignment.spaceAround,
                               children: [
                                 DigitalDisplay(
-                                  //TODO: add snapshot data here
-                                  value: sensorNodeSnapshot.temperature,
+                                  value: deviceSnapshot.temperature,
                                   valueType: 'temperature',
                                 ),
                                 DigitalDisplay(
-                                  //TODO: add snapshot data here
-                                  value: sensorNodeSnapshot.humidity,
+                                  value: deviceSnapshot.humidity,
                                   valueType: 'humidity',
                                 )
                               ],
@@ -165,8 +152,7 @@ class _SensorNodeCardState extends State<SensorNodeCard> with AutomaticKeepAlive
                                 alignment: Alignment.center,
                                 child: RadialGauge(
                                     valueType: 'soilMoisture',
-                                    //TODO: add snapshot data here
-                                    value:  sensorNodeSnapshot.soilMoisture,
+                                    value:  deviceSnapshot.soilMoisture,
                                     limit: 100)),
                           )
                         ],
@@ -214,8 +200,4 @@ class _SensorNodeCardState extends State<SensorNodeCard> with AutomaticKeepAlive
       ),
     );
   }
-
-  @override
-  // TODO: implement wantKeepAlive
-  bool get wantKeepAlive => true;
 }

--- a/lib/components/devices/cards/sensor_node_card.dart
+++ b/lib/components/devices/cards/sensor_node_card.dart
@@ -78,7 +78,6 @@ class _SensorNodeCardState extends State<SensorNodeCard> with AutomaticKeepAlive
     );
 
     List<SensorNodeSnapshot?> senSnapshotList = context.watch<DevicesProvider>().sensorNodeSnapshotList;
-    _logs.error(message: senSnapshotList.toString());
     SensorNodeSnapshot? sensorNodeSnapshot;
 
     if (senSnapshotList.isNotEmpty) {

--- a/lib/components/devices/sensor_node_subpage/sensor_node_card_expanded.dart
+++ b/lib/components/devices/sensor_node_subpage/sensor_node_card_expanded.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:smmic/models/device_data_models.dart';
+import 'package:smmic/providers/devices_provider.dart';
 import 'package:smmic/services/devices_services.dart';
 import 'package:smmic/sqlitedb/db.dart';
 import 'package:smmic/subcomponents/devices/device_dialog.dart';
@@ -28,11 +30,12 @@ class SensorNodeCardExpanded extends StatefulWidget {
 class _SensorNodeCardExpandedState extends State<SensorNodeCardExpanded> {
   final DateTimeFormatting _dateTimeFormatting = DateTimeFormatting();
 
-  SensorNodeSnapshot? cardReadings;
-  SensorNodeSnapshot? sqlCardReadings;
-
   @override
   Widget build(BuildContext context) {
+
+    SensorNodeSnapshot deviceSnapshot = context.watch<DevicesProvider>().sensorNodeSnapshotMap[widget.deviceID]
+        ?? SensorNodeSnapshot.placeHolder(deviceId: widget.deviceID);
+
     double height = MediaQuery.sizeOf(context).height;
 
     return Container(
@@ -51,85 +54,67 @@ class _SensorNodeCardExpandedState extends State<SensorNodeCardExpanded> {
             )
           ]
       ),
-      child: FutureBuilder(
-        future: DatabaseHelper.getAllReadings(widget.deviceID),
-        builder: (context, futureSnapshot) {
-          sqlCardReadings = futureSnapshot.data;
-          return StreamBuilder<SensorNodeSnapshot>(
-            stream: widget.streamController,
-            builder: (context, readingsSnapshot) {
-              if(readingsSnapshot.hasData && readingsSnapshot.data?.deviceID == widget.deviceID){
-                cardReadings = readingsSnapshot.data;
-              }
-              final batteryLevel = cardReadings?.batteryLevel ?? sqlCardReadings?.batteryLevel ?? 00;
-              final humidity = cardReadings?.humidity ?? sqlCardReadings?.humidity ?? 00;
-              final temperature = cardReadings?.temperature ?? sqlCardReadings?.temperature ?? 00;
-              final soilMoisture = cardReadings?.soilMoisture ?? sqlCardReadings?.soilMoisture ?? 00;
-              return Column(
-                children: [
-                  Expanded(
-                      flex: 1,
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 20),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            const BatteryLevel(
-                                batteryLevel: 11.0,
-                                alignmentAdjust: 1,
-                                shrinkPercentSign: false
-                            ),
-                            Text(
-                                _dateTimeFormatting.formatTime(widget.snapshot == null ? DateTime.now() : widget.snapshot!.timestamp),
-                                style: const TextStyle(fontFamily: 'Inter', fontSize: 20)
-                            )
-                          ],
-                        ),
-                      )
-                  ),
-                  Expanded(
-                    flex: 4,
-                    child: RadialGauge(
-                        valueType: 'soilMoisture',
-                        value: soilMoisture,
-                        limit: 100,
-                        scaleMultiplier: 1.5
+      child: Column(
+        children: [
+          Expanded(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const BatteryLevel(
+                        batteryLevel: 11.0,
+                        alignmentAdjust: 1,
+                        shrinkPercentSign: false
                     ),
-                  ),
-                  Expanded(
-                      flex: 3,
-                      child: Container(
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            SizedBox(
-                              width: 160,
-                              child: RadialGauge(
-                                valueType: 'temperature',
-                                value: temperature,
-                                limit: 100,
-                                radiusMultiplier: 0.9,
-                              ),
-                            ),
-                            SizedBox(
-                              width: 160,
-                              child: RadialGauge(
-                                valueType: 'humidity',
-                                value: humidity,
-                                limit: 100,
-                                radiusMultiplier: 0.9,
-                              ),
-                            ),
-                          ],
-                        ),
-                      )
-                  )
-                ],
-              );
-            }
-          );
-        }
-      ),
+                    Text(
+                        _dateTimeFormatting.formatTime(widget.snapshot == null ? DateTime.now() : widget.snapshot!.timestamp),
+                        style: const TextStyle(fontFamily: 'Inter', fontSize: 20)
+                    )
+                  ],
+                ),
+              )
+          ),
+          Expanded(
+            flex: 4,
+            child: RadialGauge(
+                valueType: 'soilMoisture',
+                value: deviceSnapshot.soilMoisture,
+                limit: 100,
+                scaleMultiplier: 1.5
+            ),
+          ),
+          Expanded(
+              flex: 3,
+              child: Container(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    SizedBox(
+                      width: 160,
+                      child: RadialGauge(
+                        valueType: 'temperature',
+                        value: deviceSnapshot.temperature,
+                        limit: 100,
+                        radiusMultiplier: 0.9,
+                      ),
+                    ),
+                    SizedBox(
+                      width: 160,
+                      child: RadialGauge(
+                        valueType: 'humidity',
+                        value: deviceSnapshot.humidity,
+                        limit: 100,
+                        radiusMultiplier: 0.9,
+                      ),
+                    ),
+                  ],
+                ),
+              )
+          )
+        ],
+      )
     );
   }
 }

--- a/lib/components/devices/sensor_node_subpage/stacked_line.dart
+++ b/lib/components/devices/sensor_node_subpage/stacked_line.dart
@@ -35,9 +35,11 @@ class _StackedLineChartState extends State<StackedLineChart> {
       future: DatabaseHelper.chartReadings(widget.deviceID),
       builder: (context, futureSnapshot) {
         final List<SensorNodeSnapshot>? chartData = futureSnapshot.data;
+
         if(futureSnapshot.connectionState == ConnectionState.waiting) {
           return const Center(child: CircularProgressIndicator(),);
         }
+
         return Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
@@ -164,11 +166,11 @@ class _StackedLineChartState extends State<StackedLineChart> {
   }
 
   List<Text> _buildXAxisLabels({required List<String> marks}){
-    int interval = 10;
     TextStyle style = const TextStyle(fontSize: 10);
     List<String> finalMarks = [];
 
     for(String mark in marks){
+      print(mark);
       List<String>buffer = mark.split(":");
       String f = "${buffer[0]}:${buffer[1]}";
       finalMarks.add(f);

--- a/lib/components/drawer.dart
+++ b/lib/components/drawer.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:smmic/pages/QRcode.dart';
 import 'package:smmic/pages/accountinfo.dart';
 import 'package:smmic/pages/lab.dart';
-import 'package:smmic/pages/mqtt.dart';
+import 'package:smmic/pages/local_connect.dart';
 import 'package:smmic/pages/settings.dart';
 
 class ComponentDrawer extends StatefulWidget {

--- a/lib/constants/api.dart
+++ b/lib/constants/api.dart
@@ -1,7 +1,7 @@
 /// Defines API constants (routes, configs if any)
 class ApiRoutes {
   //10.0.2.2
-  final String _baseURL = 'http://127.0.0.1:8000/api';
+  final String _baseURL = 'http://10.0.2.2:8000/api';
   final String _loginURL = '/auth/jwt/create/';
   final String _logoutURL = '/blacklist';
   final String _registerURL = '/djoser/users/';
@@ -14,7 +14,7 @@ class ApiRoutes {
   final String _updateSNDeviceName = '/updateuserSNdevicesname/';
 
   ///Django Channels/Websocket URL Connections
-  final String _wsBaseURL = 'ws://127.0.0.1:8000/ws';
+  final String _wsBaseURL = 'ws://10.0.2.2:8000/ws';
   final String _getSNreadings = '/SNreadings/';
   final String _getSMAlerts = '/sm_alerts/';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,6 +109,7 @@ class _AuthGateState extends State<AuthGate> {
             context.read<UserDataProvider>().init();
             context.read<DevicesProvider>().init(context);
             context.read<AuthProvider>().init();
+            context.read<MqttProvider>().registerContext(context: context);
 
             _apiRequest.connectSeReadingsChannel(
                 route: _apiRoutes.seReadingsWs,
@@ -125,7 +126,6 @@ class _AuthGateState extends State<AuthGate> {
             return const Stack(
               children: [
                 MyBottomNav(indexPage: 0),
-                /*PreloadDevices()*/
               ],
             );
           }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,6 +82,17 @@ class _AuthGateState extends State<AuthGate> {
 
   @override
   Widget build(BuildContext context) {
+
+    _apiRequest.connectSeReadingsChannel(
+        route: _apiRoutes.seReadingsWs,
+        context: context
+    );
+
+    _apiRequest.connectAlertsChannel(
+        route: _apiRoutes.seAlertsWs,
+        context: context
+    );
+
     return FutureBuilder(
         future: _authCheck(),
         builder: (context, AsyncSnapshot<bool> authCheckSnapshot) {
@@ -91,32 +102,25 @@ class _AuthGateState extends State<AuthGate> {
               child: const Center(child: CircularProgressIndicator()),
             );
           }
+
           if (authCheckSnapshot.hasError) {
             return const Center(
               child: Text('An unexpected error has occurred'),
             );
           }
+
           if (authCheckSnapshot.hasData) {
             bool authCheck = authCheckSnapshot.data!;
             if (!authCheck) {
               return const LoginPage();
             }
+
             // initiate user data when logged in
             context.read<UserDataProvider>().init();
-            context.read<DevicesProvider>().init(context);
+            context.read<DevicesProvider>().init();
             context.read<AuthProvider>().init();
             context.read<MqttProvider>().registerContext(context: context);
 
-            _apiRequest.connectSeReadingsChannel(
-                route: _apiRoutes.seReadingsWs,
-                context: context
-            );
-            _apiRequest.connectAlertsChannel(
-                route: _apiRoutes.seAlertsWs,
-                context: context
-            );
-
-            // TODO: fix this hack
             return const Stack(
               children: [
                 MyBottomNav(indexPage: 0),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,9 +72,7 @@ class _AuthGateState extends State<AuthGate> {
 
     String? login = await _sharedPrefsUtils.getLogin();
     if (login == null) {
-      _logs.info(
-          message:
-              'did not find login key from SharedPreferences, returning LoginPage()');
+      _logs.info(message:'did not find login key from SharedPreferences, returning LoginPage()');
       return false;
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:smmic/components/bottomnavbar/bottom_nav_bar.dart';
+import 'package:smmic/constants/api.dart';
 import 'package:smmic/preload/preloaddevices.dart';
 import 'package:smmic/providers/device_settings_provider.dart';
 import 'package:smmic/pages/login.dart';
@@ -9,6 +10,7 @@ import 'package:smmic/providers/mqtt_provider.dart';
 import 'package:smmic/providers/theme_provider.dart';
 import 'package:smmic/providers/auth_provider.dart';
 import 'package:smmic/providers/user_data_provider.dart';
+import 'package:smmic/utils/api.dart';
 import 'package:smmic/utils/global_navigator.dart';
 import 'package:smmic/utils/logs.dart';
 import 'package:smmic/utils/shared_prefs.dart';
@@ -60,8 +62,10 @@ class AuthGate extends StatefulWidget {
 }
 
 class _AuthGateState extends State<AuthGate> {
-  // utils
+  // utils, dependencies
   final SharedPrefsUtils _sharedPrefsUtils = SharedPrefsUtils();
+  final ApiRequest _apiRequest = ApiRequest();
+  final ApiRoutes _apiRoutes = ApiRoutes();
 
   // providers
   final AuthProvider _authProvider = AuthProvider();
@@ -103,8 +107,19 @@ class _AuthGateState extends State<AuthGate> {
             }
             // initiate user data when logged in
             context.read<UserDataProvider>().init();
-            context.read<DevicesProvider>().init();
+            context.read<DevicesProvider>().init(context);
             context.read<AuthProvider>().init();
+
+            _apiRequest.connectSeReadingsChannel(
+                route: _apiRoutes.seReadingsWs,
+                streamController: context.read<DevicesProvider>().seSnapshotStreamController,
+                context: context
+            );
+            _apiRequest.connectAlertsChannel(
+                route: _apiRoutes.seAlertsWs,
+                streamController: context.read<DevicesProvider>().alertsStreamController,
+                context: context
+            );
 
             // TODO: fix this hack
             return const Stack(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,10 +67,6 @@ class _AuthGateState extends State<AuthGate> {
   final ApiRequest _apiRequest = ApiRequest();
   final ApiRoutes _apiRoutes = ApiRoutes();
 
-  // providers
-  final AuthProvider _authProvider = AuthProvider();
-  final UserDataProvider _userDataProvider = UserDataProvider();
-
   Future<bool> _authCheck() async {
     _logs.info2(message: 'executing _authCheck()');
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,12 +109,10 @@ class _AuthGateState extends State<AuthGate> {
 
             _apiRequest.connectSeReadingsChannel(
                 route: _apiRoutes.seReadingsWs,
-                streamController: context.read<DevicesProvider>().seSnapshotStreamController,
                 context: context
             );
             _apiRequest.connectAlertsChannel(
                 route: _apiRoutes.seAlertsWs,
-                streamController: context.read<DevicesProvider>().alertsStreamController,
                 context: context
             );
 

--- a/lib/models/device_data_models.dart
+++ b/lib/models/device_data_models.dart
@@ -1,5 +1,27 @@
 import 'dart:convert';
 
+enum SinkNodeKeys{
+  deviceID('device_id'),
+  deviceName('name'),
+  latitude('latitude'),
+  longitude('longitude'),
+  registeredSensorNodes('sensor_nodes');
+
+  final String key;
+  const SinkNodeKeys(this.key);
+}
+
+enum SensorNodeKeys{
+  deviceID('device_id'),
+  deviceName('name'),
+  latitude('latitude'),
+  longitude('longitude'),
+  sinkNode('sink_node');
+
+  final String key;
+  const SensorNodeKeys(this.key);
+}
+
 class Device {
   final String deviceID;
   String deviceName;
@@ -33,11 +55,11 @@ class SinkNode extends Device {
   //TODO: add logic to check if a device already exists (caching or from shared prefs)
   factory SinkNode.fromJSON(Map<String, dynamic> deviceInfo) {
     return SinkNode._internal(
-      deviceID: deviceInfo['deviceID'],
-      deviceName: deviceInfo['deviceName'],
-      longitude: deviceInfo['longitude'],
-      latitude: deviceInfo['latitude'],
-      registeredSensorNodes: deviceInfo['registeredSensorNodes']
+      deviceID: deviceInfo[SinkNodeKeys.deviceID.key],
+      deviceName: deviceInfo[SinkNodeKeys.deviceName.key],
+      longitude: deviceInfo[SinkNodeKeys.longitude.key],
+      latitude: deviceInfo[SinkNodeKeys.latitude.key],
+      registeredSensorNodes: deviceInfo[SinkNodeKeys.registeredSensorNodes.key]
     );
   }
 }
@@ -56,11 +78,11 @@ class SensorNode extends Device {
   //TODO: add logic to check if a device already exists (caching or from shared prefs)
   factory SensorNode.fromJSON(Map<String, dynamic> deviceInfo) {
     return SensorNode._internal(
-      deviceID: deviceInfo['deviceID'],
-      deviceName: deviceInfo['deviceName'],
-      latitude:deviceInfo['latitude'],
-      longitude: deviceInfo['longitude'],
-      registeredSinkNode: deviceInfo['sinkNodeID']
+      deviceID: deviceInfo[SensorNodeKeys.deviceID.key],
+      deviceName: deviceInfo[SensorNodeKeys.deviceName.key],
+      latitude:deviceInfo[SensorNodeKeys.latitude.key],
+      longitude: deviceInfo[SensorNodeKeys.longitude.key],
+      registeredSinkNode: deviceInfo[SensorNodeKeys.sinkNode.key]
     );
   }
 }

--- a/lib/models/device_data_models.dart
+++ b/lib/models/device_data_models.dart
@@ -105,6 +105,43 @@ class SensorNodeSnapshot {
     );
   }
 
+  static SensorNodeSnapshot? dynamicSerializer({required var data}) {
+    SensorNodeSnapshot? finalSnapshot;
+
+    if (data is Map<String, dynamic>) {
+      // TODO: verify keys first
+      finalSnapshot = SensorNodeSnapshot.fromJSON(data);
+    } else if (data is String) {
+      // assuming that if the reading variable is a string, it is an mqtt payload
+      Map<String, dynamic> fromStringMap = {};
+      List<String> outerSplit = data.split(';');
+
+      fromStringMap.addAll({
+        'device_id': outerSplit[1],
+        'timestamp': outerSplit[2],
+      });
+
+      List<String> dataSplit = outerSplit[3].split('&');
+
+      for (String keyValue in dataSplit) {
+        try {
+          List<String> x = keyValue.split(':');
+          fromStringMap.addAll({x[0]: x[1]});
+        } on FormatException catch (e) {
+          break;
+        }
+      }
+
+      // create a new sensor node snapshot object from the new string map
+      finalSnapshot = SensorNodeSnapshot.fromJSON(fromStringMap);
+
+    } else if (data is SensorNodeSnapshot) {
+      finalSnapshot = data;
+    }
+
+    return finalSnapshot;
+  }
+
   Map<String,dynamic> toJson() => {
     'device_id' : deviceID,
     'timestamp' : timestamp.toIso8601String(),

--- a/lib/pages/devices.dart
+++ b/lib/pages/devices.dart
@@ -8,6 +8,7 @@ import 'package:smmic/components/devices/cards/sink_node_card.dart';
 import 'package:smmic/components/devices/bottom_drawer.dart';
 import 'package:smmic/models/device_data_models.dart';
 import 'package:smmic/pages/dashboard.dart';
+import 'package:smmic/pages/devices_subpages/sensor_node_subpage.dart';
 import 'package:smmic/providers/device_settings_provider.dart';
 import 'package:smmic/providers/devices_provider.dart';
 import 'package:smmic/providers/theme_provider.dart';
@@ -30,15 +31,6 @@ class _Devices extends State<Devices> {
 
   final Logs _logs = Logs(tag: 'devices.dart');
 
-  final UserDataServices _userDataServices = UserDataServices();
-  final DevicesServices _devicesServices = DevicesServices();
-  final ApiRequest _apiRequest = ApiRequest();
-  final ApiRoutes _apiRoutes = ApiRoutes();
-  final DevicesProvider _devicesProvider = DevicesProvider();
-
-  // merged stream group
-  // TODO: wrap `mergedStream` inside a provider
-
   @override
   void initState() {
     super.initState();
@@ -47,13 +39,6 @@ class _Devices extends State<Devices> {
   @override
   Widget build(BuildContext context) {
     Color bgColor = context.watch<UiProvider>().isDark ? Colors.black : Colors.white;
-    late final Stream mergedStream;
-
-    mergedStream = StreamGroup.merge([
-      context.watch<DevicesProvider>().seSnapshotStreamController!.stream,
-      context.watch<DevicesProvider>().alertsStreamController!.stream,
-      context.watch<DevicesProvider>().mqttStreamController!.stream,
-    ]);
 
     return Scaffold(
       backgroundColor: bgColor,
@@ -68,27 +53,60 @@ class _Devices extends State<Devices> {
             )
           ]
       ),
-      body: StreamBuilder(
-          stream: mergedStream,
-          builder: (context, snapshot) {
-            // check for data from streams
-            if (snapshot.hasData) {
-              _updateProviders(
-                  context: context,
-                  data: snapshot.data
-              );
-            } else if (snapshot.hasError) {
-              // TODO: show err message
-            }
-
-            return _buildList(
-                sinkNodeList: context.watch<DevicesProvider>().sinkNodeList,
-                sensorNodeList: context.watch<DevicesProvider>().sensorNodeList,
-                options: context.watch<DeviceListOptionsNotifier>().enabledConditions
-            );
-          }
+      body: _buildList(
+        sinkNodeList: context.watch<DevicesProvider>().sinkNodeList,
+        sensorNodeList: context.watch<DevicesProvider>().sensorNodeList,
+        options: context.watch<DeviceListOptionsNotifier>().enabledConditions,
+        seSnapShotMap: context.watch<DevicesProvider>().sensorNodeSnapshotMap,
       )
     );
+  }
+
+  Widget _buildList({
+    required List<SinkNode> sinkNodeList,
+    required List<SensorNode> sensorNodeList,
+    required Map<String, bool Function(Widget)> options,
+    required Map<String, SensorNodeSnapshot> seSnapShotMap}){
+
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          ..._buildCards(
+            sinkNodeList: sinkNodeList,
+            sensorNodeList: sensorNodeList,
+            options: options,
+            seSnapshotMap: seSnapShotMap
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildCards({
+    required List<SinkNode> sinkNodeList,
+    required List<SensorNode> sensorNodeList,
+    required Map<String, bool Function(Widget)> options,
+    required Map<String, SensorNodeSnapshot> seSnapshotMap}){
+
+    List<Widget> cards = [];
+    for (int i = 0; i < sinkNodeList.length; i++) {
+      cards.add(SinkNodeCard(deviceInfo: sinkNodeList[i]));
+
+      //List<SensorNode> sensorGroup = sensorNodeList.where((item) => item.registeredSinkNode == sinkNodeList[i].deviceID).toList();
+      for (int x = 0; x < sensorNodeList.length; x++) {
+        if (sensorNodeList[x].registeredSinkNode == sinkNodeList[i].deviceID) {
+          SensorNodeSnapshot deviceSnapshot = seSnapshotMap[sensorNodeList[x].deviceID] ?? SensorNodeSnapshot.placeHolder(deviceId: sensorNodeList[x].deviceID);
+          cards.add(SensorNodeCard(deviceInfo: sensorNodeList[x], deviceSnapshot: deviceSnapshot)
+          );
+        }
+      }
+    }
+
+    return cards.where((card) {
+      return options.keys
+          .map((optionKey) => options[optionKey]!(card))
+          .any((result) => result);
+    }).toList();
   }
 
   void _updateProviders({required BuildContext context, required var data}) {
@@ -101,46 +119,5 @@ class _Devices extends State<Devices> {
       context.read<DevicesProvider>().setNewSensorSnapshot(data);
     }
     return;
-  }
-
-  Widget _buildList({
-    required List<SinkNode> sinkNodeList,
-    required List<SensorNode> sensorNodeList,
-    required Map<String, bool Function(Widget)> options}){
-
-    return SingleChildScrollView(
-      child: Column(
-        children: [
-          ..._buildCards(
-              sinkNodeList: sinkNodeList,
-              sensorNodeList: sensorNodeList,
-              options: options
-          ),
-        ],
-      ),
-    );
-  }
-
-  List<Widget> _buildCards({
-    required List<SinkNode> sinkNodeList,
-    required List<SensorNode> sensorNodeList,
-    required Map<String, bool Function(Widget)> options}){
-
-    List<Widget> cards = [];
-    for (int i = 0; i < sinkNodeList.length; i++) {
-      cards.add(SinkNodeCard(deviceInfo: sinkNodeList[i]));
-      //List<SensorNode> sensorGroup = sensorNodeList.where((item) => item.registeredSinkNode == sinkNodeList[i].deviceID).toList();
-      for (int x = 0; x < sensorNodeList.length; x++) {
-        if (sensorNodeList[x].registeredSinkNode == sinkNodeList[i].deviceID) {
-          cards.add(SensorNodeCard(deviceInfo: sensorNodeList[x])
-          );
-        }
-      }
-    }
-    return cards.where((card) {
-      return options.keys
-          .map((optionKey) => options[optionKey]!(card))
-          .any((result) => result);
-    }).toList();
   }
 }

--- a/lib/pages/devices.dart
+++ b/lib/pages/devices.dart
@@ -98,7 +98,7 @@ class _Devices extends State<Devices> {
     } else if (data is SMAlerts) {
       // TODO: handle from alerts
     } else if (data is String) {
-      // TODO: handle from mqtt
+      context.read<DevicesProvider>().setNewSensorSnapshot(data);
     }
     return;
   }

--- a/lib/pages/devices.dart
+++ b/lib/pages/devices.dart
@@ -54,8 +54,8 @@ class _Devices extends State<Devices> {
           ]
       ),
       body: _buildList(
-        sinkNodeList: context.watch<DevicesProvider>().sinkNodeList,
-        sensorNodeList: context.watch<DevicesProvider>().sensorNodeList,
+        sinkNodeMap: context.watch<DevicesProvider>().sinkNodeMap,
+        sensorNodeMap: context.watch<DevicesProvider>().sensorNodeMap,
         options: context.watch<DeviceListOptionsNotifier>().enabledConditions,
         seSnapShotMap: context.watch<DevicesProvider>().sensorNodeSnapshotMap,
       )
@@ -63,8 +63,8 @@ class _Devices extends State<Devices> {
   }
 
   Widget _buildList({
-    required List<SinkNode> sinkNodeList,
-    required List<SensorNode> sensorNodeList,
+    required Map<String, SinkNode> sinkNodeMap,
+    required Map<String, SensorNode> sensorNodeMap,
     required Map<String, bool Function(Widget)> options,
     required Map<String, SensorNodeSnapshot> seSnapShotMap}){
 
@@ -72,8 +72,8 @@ class _Devices extends State<Devices> {
       child: Column(
         children: [
           ..._buildCards(
-            sinkNodeList: sinkNodeList,
-            sensorNodeList: sensorNodeList,
+            sinkNodeMap: sinkNodeMap,
+            sensorNodeMap: sensorNodeMap,
             options: options,
             seSnapshotMap: seSnapShotMap
           ),
@@ -83,22 +83,21 @@ class _Devices extends State<Devices> {
   }
 
   List<Widget> _buildCards({
-    required List<SinkNode> sinkNodeList,
-    required List<SensorNode> sensorNodeList,
+    required Map<String, SinkNode> sinkNodeMap,
+    required Map<String, SensorNode> sensorNodeMap,
     required Map<String, bool Function(Widget)> options,
     required Map<String, SensorNodeSnapshot> seSnapshotMap}){
 
     List<Widget> cards = [];
-    for (int i = 0; i < sinkNodeList.length; i++) {
-      cards.add(SinkNodeCard(deviceInfo: sinkNodeList[i]));
+    List<String> sinkNodeMapKeys = sinkNodeMap.keys.toList();
 
-      //List<SensorNode> sensorGroup = sensorNodeList.where((item) => item.registeredSinkNode == sinkNodeList[i].deviceID).toList();
-      for (int x = 0; x < sensorNodeList.length; x++) {
-        if (sensorNodeList[x].registeredSinkNode == sinkNodeList[i].deviceID) {
-          SensorNodeSnapshot deviceSnapshot = seSnapshotMap[sensorNodeList[x].deviceID] ?? SensorNodeSnapshot.placeHolder(deviceId: sensorNodeList[x].deviceID);
-          cards.add(SensorNodeCard(deviceInfo: sensorNodeList[x], deviceSnapshot: deviceSnapshot)
-          );
-        }
+    for (String sinkId in sinkNodeMapKeys) {
+      cards.add(SinkNodeCard(deviceInfo: sinkNodeMap[sinkId]!));
+      for (String sensorId in sinkNodeMap[sinkId]!.registeredSensorNodes) {
+        cards.add(SensorNodeCard(
+            deviceInfo: sensorNodeMap[sensorId]!,
+            deviceSnapshot: seSnapshotMap[sensorId]
+        ));
       }
     }
 

--- a/lib/pages/devices.dart
+++ b/lib/pages/devices.dart
@@ -71,7 +71,6 @@ class _Devices extends State<Devices> {
       body: StreamBuilder(
           stream: mergedStream,
           builder: (context, snapshot) {
-
             // check for data from streams
             if (snapshot.hasData) {
               _updateProviders(
@@ -81,6 +80,7 @@ class _Devices extends State<Devices> {
             } else if (snapshot.hasError) {
               // TODO: show err message
             }
+
             return _buildList(
                 sinkNodeList: context.watch<DevicesProvider>().sinkNodeList,
                 sensorNodeList: context.watch<DevicesProvider>().sensorNodeList,
@@ -108,16 +108,17 @@ class _Devices extends State<Devices> {
     required List<SensorNode> sensorNodeList,
     required Map<String, bool Function(Widget)> options}){
 
-    return ListView(
-      shrinkWrap: true,
-      addAutomaticKeepAlives: true,
-      children: [
-        ..._buildCards(
-          sinkNodeList: sinkNodeList,
-          sensorNodeList: sensorNodeList,
-          options: options
-        ),
-      ],
+    return SingleChildScrollView(
+
+      child: Column(
+        children: [
+          ..._buildCards(
+              sinkNodeList: sinkNodeList,
+              sensorNodeList: sensorNodeList,
+              options: options
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/pages/devices.dart
+++ b/lib/pages/devices.dart
@@ -109,7 +109,6 @@ class _Devices extends State<Devices> {
     required Map<String, bool Function(Widget)> options}){
 
     return SingleChildScrollView(
-
       child: Column(
         children: [
           ..._buildCards(

--- a/lib/pages/lab.dart
+++ b/lib/pages/lab.dart
@@ -22,6 +22,7 @@ class MergedStreamExample extends StatelessWidget {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return CircularProgressIndicator();
             } else if (snapshot.hasData) {
+              print('new - data -----> ${snapshot.data}');
               if (snapshot.data is int){
                 return Text('Latest data: Stream 1 - ${snapshot.data}');
               } else if (snapshot.data is String) {

--- a/lib/pages/local_connect.dart
+++ b/lib/pages/local_connect.dart
@@ -57,7 +57,6 @@ class _LocalConnectState extends State<LocalConnect> {
                       else if ([MqttConnectionState.disconnected, MqttConnectionState.faulted].contains(connectionState)) {
                         Exception? err = await context.read<MqttProvider>().initClient(
                             clientIdentifier: '',
-                            streamController: context.read<DevicesProvider>().mqttStreamController!
                         );
                         if (err != null && context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/pages/local_connect.dart
+++ b/lib/pages/local_connect.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mqtt_client/mqtt_server_client.dart';
 import 'package:provider/provider.dart';
+import 'package:smmic/providers/devices_provider.dart';
 import 'package:smmic/providers/mqtt_provider.dart';
 import 'package:smmic/providers/theme_provider.dart';
 import 'package:mqtt_client/mqtt_client.dart';
@@ -54,7 +55,10 @@ class _LocalConnectState extends State<LocalConnect> {
                         context.read<MqttProvider>().disconnectClient();
                       }
                       else if ([MqttConnectionState.disconnected, MqttConnectionState.faulted].contains(connectionState)) {
-                        Exception? err = await context.read<MqttProvider>().initClient(clientIdentifier: '');
+                        Exception? err = await context.read<MqttProvider>().initClient(
+                            clientIdentifier: '',
+                            streamController: context.read<DevicesProvider>().mqttStreamController!
+                        );
                         if (err != null && context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                               const SnackBar(content: Text('Unable to connect to broker, try again later'))

--- a/lib/pages/local_connect.dart
+++ b/lib/pages/local_connect.dart
@@ -21,10 +21,6 @@ class _LocalConnectState extends State<LocalConnect> {
   // mqtt setup
   final mqttClient = MqttServerClient('10.0.2.2', '');
 
-  // vars
-  // ignore: prefer_final_fields
-  MqttConnectionState _mqttConnectionState = MqttConnectionState.disconnected;
-
   @override
   void initState() {
     super.initState();

--- a/lib/providers/devices_provider.dart
+++ b/lib/providers/devices_provider.dart
@@ -34,7 +34,7 @@ class DevicesProvider extends ChangeNotifier {
   // mqtt stream
   StreamController<String>? _mqttStreamController;
   StreamController<String>? get mqttStreamController => _mqttStreamController;
-  
+
   // ws channels
   // sensor readings ws
   WebSocketChannel? _seReadingsChannel;
@@ -203,6 +203,8 @@ class DevicesProvider extends ChangeNotifier {
   void setNewSensorSnapshot(var reading) {
     SensorNodeSnapshot? finalSnapshot;
 
+    print(reading.toString());
+
     if (reading is Map<String, dynamic>) {
       // TODO: verify keys first
       finalSnapshot = SensorNodeSnapshot.fromJSON(reading);
@@ -230,6 +232,7 @@ class DevicesProvider extends ChangeNotifier {
 
       // create a new sensor node snapshot object from the new string map
       finalSnapshot = SensorNodeSnapshot.fromJSON(fromStringMap);
+
     } else if (reading is SensorNodeSnapshot) {
       finalSnapshot = reading;
     }

--- a/lib/providers/devices_provider.dart
+++ b/lib/providers/devices_provider.dart
@@ -14,13 +14,12 @@ import 'package:smmic/utils/shared_prefs.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 class DevicesProvider extends ChangeNotifier {
-  
   // dependencies
   final Logs _logs = Logs(tag: 'DevicesProvider()');
   final DevicesServices _devicesServices = DevicesServices();
   final DeviceUtils _deviceUtils = DeviceUtils();
   final SharedPrefsUtils _sharedPrefsUtils = SharedPrefsUtils();
-  
+
   // api helpers, dependencies
   final ApiRoutes _apiRoutes = ApiRoutes();
   final ApiRequest _apiRequest = ApiRequest();
@@ -82,11 +81,11 @@ class DevicesProvider extends ChangeNotifier {
     StreamController<SMAlerts> alSController = StreamController<SMAlerts>.broadcast();
     StreamController<String> mqttSController = StreamController<String>.broadcast();
 
-    WebSocketChannel seReadingsChannel = _apiRequest.snReadingsChannel(
+    WebSocketChannel? seReadingsChannel = _apiRequest.connectSeReadingsChannel(
         route: _apiRoutes.seReadingsWs,
         streamController: seSController
     );
-    WebSocketChannel alertsChannel = _apiRequest.alertsChannel(
+    WebSocketChannel? alertsChannel = _apiRequest.connectAlertsChannel(
         route: _apiRoutes.seAlertsWs,
         streamController: alSController
     );
@@ -182,8 +181,8 @@ class DevicesProvider extends ChangeNotifier {
   }
   
   void _setWebSocketChannels({
-    required WebSocketChannel seReadingsChannel,
-    required WebSocketChannel alertsChannel}) {
+    required WebSocketChannel? seReadingsChannel,
+    required WebSocketChannel? alertsChannel}) {
     
     _seReadingsChannel = seReadingsChannel;
     _alertsChannel = alertsChannel;

--- a/lib/providers/devices_provider.dart
+++ b/lib/providers/devices_provider.dart
@@ -78,7 +78,31 @@ class DevicesProvider extends ChangeNotifier {
     Map<String, dynamic>? userData = await _sharedPrefsUtils.getUserData();
     Map<String, dynamic> tokens = await _sharedPrefsUtils.getTokens(access: true);
 
+    StreamController<SensorNodeSnapshot> seSController = StreamController<SensorNodeSnapshot>.broadcast();
+    StreamController<SMAlerts> alSController = StreamController<SMAlerts>.broadcast();
+    StreamController<String> mqttSController = StreamController<String>.broadcast();
+
+    WebSocketChannel seReadingsChannel = _apiRequest.snReadingsChannel(
+        route: _apiRoutes.seReadingsWs,
+        streamController: seSController
+    );
+    WebSocketChannel alertsChannel = _apiRequest.alertsChannel(
+        route: _apiRoutes.seAlertsWs,
+        streamController: alSController
+    );
+
+    _setStreamControllers(
+        seSnapshotStreamController: seSController,
+        alertsStreamController: alSController,
+        mqttStreamController: mqttSController
+    );
+    _setWebSocketChannels(
+        seReadingsChannel: seReadingsChannel,
+        alertsChannel: alertsChannel
+    );
+
     if(userData == null){
+      notifyListeners();
       return;
     }
 
@@ -143,29 +167,6 @@ class DevicesProvider extends ChangeNotifier {
     //_logs.info(message: 'devices shared prefs init: $sinkNodeSharedPrefs');
     /*listenToStream();*/
 
-    StreamController<SensorNodeSnapshot> seSController = StreamController<SensorNodeSnapshot>.broadcast();
-    StreamController<SMAlerts> alSController = StreamController<SMAlerts>.broadcast();
-    StreamController<String> mqttSController = StreamController<String>.broadcast();
-
-    WebSocketChannel seReadingsChannel = _apiRequest.snReadingsChannel(
-        route: _apiRoutes.seReadingsWs,
-        streamController: seSController
-    );
-    WebSocketChannel alertsChannel = _apiRequest.alertsChannel(
-        route: _apiRoutes.seAlertsWs,
-        streamController: alSController
-    );
-
-    _setStreamControllers(
-        seSnapshotStreamController: seSController,
-        alertsStreamController: alSController,
-        mqttStreamController: mqttSController
-    );
-    _setWebSocketChannels(
-        seReadingsChannel: seReadingsChannel,
-        alertsChannel: alertsChannel
-    );
-
     notifyListeners();
     _logs.success(message: 'init() done');
   }
@@ -178,7 +179,7 @@ class DevicesProvider extends ChangeNotifier {
     _seSnapshotStreamController = seSnapshotStreamController;
     _alertsStreamController = alertsStreamController;
     _mqttStreamController = mqttStreamController;
-}
+  }
   
   void _setWebSocketChannels({
     required WebSocketChannel seReadingsChannel,

--- a/lib/providers/devices_provider.dart
+++ b/lib/providers/devices_provider.dart
@@ -24,28 +24,12 @@ class DevicesProvider extends ChangeNotifier {
   final ApiRoutes _apiRoutes = ApiRoutes();
   final ApiRequest _apiRequest = ApiRequest();
 
-  // stream controllers
-  // se snapshot stream
-  StreamController<SensorNodeSnapshot>? _seSnapshotStreamController;
-  StreamController<SensorNodeSnapshot>? get seSnapshotStreamController => _seSnapshotStreamController;
-  // alerts stream
-  StreamController<SMAlerts>? _alertsStreamController;
-  StreamController<SMAlerts>? get alertsStreamController => _alertsStreamController;
-  // mqtt stream
-  StreamController<String>? _mqttStreamController;
-  StreamController<String>? get mqttStreamController => _mqttStreamController;
-
-  // devices list
-  // sink node list
-  List<SinkNode> _sinkNodeList = []; // ignore: prefer_final_fields
-  List<SinkNode> get sinkNodeList => _sinkNodeList;
-  // sensor node list
-  List<SensorNode> _sensorNodeList = [];// ignore: prefer_final_fields
-  List<SensorNode> get sensorNodeList => _sensorNodeList;
-
-  // sensor node readings
-  // List<SensorNodeSnapshot?> _sensorNodeSnapshotList = []; // ignore: prefer_final_fields
-  // List<SensorNodeSnapshot?> get sensorNodeSnapshotList => _sensorNodeSnapshotList;
+  // sink node map lists
+  Map<String, SinkNode> _sinkNodeMap = {}; // ignore: prefer_final_fields
+  Map<String, SinkNode> get sinkNodeMap => _sinkNodeMap;
+  // sensor node
+  Map<String, SensorNode> _sensorNodeMap = {}; // ignore: prefer_final_fields
+  Map<String, SensorNode> get sensorNodeMap => _sensorNodeMap;
 
   // sensor node readings map
   Map<String, SensorNodeSnapshot> _sensorNodeSnapshotMap = {}; // ignore: prefer_final_fields
@@ -72,117 +56,62 @@ class DevicesProvider extends ChangeNotifier {
 
   Map <String, Map<String,int>> _deviceAlerts = {};
 
+  Future<bool> _setDeviceListFromApi({
+    required Map<String, dynamic> userData,
+    required Map<String, dynamic> tokens}) async {
+
+    List<Map<String, dynamic>>? devices = await _devicesServices.getDevices(
+        userID: userData['UID'],
+        token: tokens['access']
+    );
+
+    if (devices == null) {
+      return false;
+    }
+
+    // acquire sink nodes and add to sinkNodeMap
+    for (Map<String, dynamic> sinkMap in devices) {
+      SinkNode sink = _deviceUtils.sinkNodeMapToObject(sinkMap);
+      _sinkNodeMap[sink.deviceID] = sink;
+    }
+
+    // acquire sensor nodes and add to sensorNodeMap
+    for (Map<String, dynamic> sinkMap in devices) {
+      List<Map<String, dynamic>> sensorMapList = sinkMap['sensor_nodes'];
+
+      for (Map<String, dynamic> sensorMap in sensorMapList) {
+        SensorNode sensor = _deviceUtils.sensorNodeMapToObject(
+            sensorMap: sensorMap,
+            sinkNodeID: sinkMap['device_id']
+        );
+        _sensorNodeMap[sensor.deviceID] = sensor;
+
+        SensorNodeSnapshot? fromSQFLiteSnapshot = await DatabaseHelper.getAllReadings(sensor.deviceID);
+        if (fromSQFLiteSnapshot != null){
+          _sensorNodeSnapshotMap[sensor.deviceID] = fromSQFLiteSnapshot;
+        }
+        List<SensorNodeSnapshot>? fromSQFLiteChartData = await DatabaseHelper.chartReadings(sensor.deviceID);
+        if (fromSQFLiteChartData != null) {
+          _sensorNodeChartDataMap[sensor.deviceID] = fromSQFLiteChartData;
+        }
+      }
+    }
+
+    notifyListeners();
+    return true;
+  }
+
   Future<void> init(BuildContext context) async {
+    // acquire user data and tokens from shared prefs
     Map<String, dynamic>? userData = await _sharedPrefsUtils.getUserData();
     Map<String, dynamic> tokens = await _sharedPrefsUtils.getTokens(access: true);
 
-    StreamController<SensorNodeSnapshot> seSController = StreamController<SensorNodeSnapshot>.broadcast();
-    StreamController<SMAlerts> alSController = StreamController<SMAlerts>.broadcast();
-    StreamController<String> mqttSController = StreamController<String>.broadcast();
-
-    if (!context.mounted) {
+    if (userData == null) {
       return;
     }
 
-    _setStreamControllers(
-        seSnapshotStreamController: seSController,
-        alertsStreamController: alSController,
-        mqttStreamController: mqttSController
-    );
-
-    // _setWebSocketChannels(
-    //     seReadingsChannel: seReadingsChannel,
-    //     alertsChannel: alertsChannel
-    // );
-
-    if(userData == null){
-      notifyListeners();
-      return;
-    }
-
-    // retrieve user devices from the api
-    _logs.info(message: 'init() executing');
-    List<Map<String, dynamic>>? devices = await _devicesServices.getDevices(userID: userData['UID'], token: tokens['access']);
-
-    // map sink nodes and append items into _sinkNodeList
-    //_logs.info(message: 'devices init: $devices');
-    for (int i = 0; i < devices.length; i++){
-      SinkNode sink = _deviceUtils.sinkNodeMapToObject(devices[i]);
-      if (_sinkNodeList.isNotEmpty && _sinkNodeList.any((item) => item.deviceID == sink.deviceID)){
-        continue;
-      }
-      _sinkNodeList.add(sink);
-    }
-
-    // map sensor nodes and append items into _sensorNodeList
-    for (int i = 0; i < devices.length; i++){
-      List<Map<String, dynamic>> sensorNodeList = devices[i]['sensor_nodes'];
-      if (sensorNodeList.isEmpty){
-        break;
-      }
-      for(int x = 0; x < sensorNodeList.length; x++){
-        SensorNode sensor = _deviceUtils.sensorNodeMapToObject(sensorMap: sensorNodeList[x], sinkNodeID: devices[i]['device_id']);
-        if (_sensorNodeList.isNotEmpty && _sensorNodeList.any((item) => item.deviceID == sensor.deviceID)) {
-          continue;
-        }
-        _sensorNodeList.add(sensor);
-
-        // load from db snapshot
-        SensorNodeSnapshot? fromDbSnapshot = await DatabaseHelper.getAllReadings(sensor.deviceID);
-        List<SensorNodeSnapshot>? fromDbChartData = await DatabaseHelper.chartReadings(sensor.deviceID);
-        if (fromDbSnapshot != null) {
-          _sensorNodeSnapshotMap[sensor.deviceID] = fromDbSnapshot;
-        }
-        if (fromDbChartData != null) {
-          _sensorNodeChartDataMap[sensor.deviceID] = fromDbChartData;
-        }
-      }
-    }
-    //_logs.info(message: "devices : $devices");
-
-    /* _sharedPrefsUtils.setSKList(sinkList: devices);*/
-    // store list of devices in the shared prefs
-    List <Map<String,dynamic>> sinkNodeSharedPrefs = []; // list of sink nodes to shared prefs
-    List<Map<String,dynamic>> sensorNodeSharedPrefs = []; // list of sensor nodes to shared prefs
-    // the outer part of this loop iterates over the sink nodes
-    for (int i = 0; i < devices.length; i++){
-      Map<String,dynamic> sink = _deviceUtils.mapSinkNode(devices[i]);
-      sinkNodeSharedPrefs.add(sink);
-      // this inner part iterates over the sensor nodes of each sink node
-      for(int j =0; j < devices[i]["sensor_nodes"].length; j++){
-        Map<String,dynamic> sensor = _deviceUtils.mapSensorNode(devices[i]['sensor_nodes'][j], sink['deviceID']);
-        sensorNodeSharedPrefs.add(sensor);
-      }
-    }
-
-
-    // helper functions that finally stores the SK and SN list in the shared prefs for fast access
-    _sharedPrefsUtils.setSKList(sinkList: sinkNodeSharedPrefs);
-    _sharedPrefsUtils.setSNList(sensorList: sensorNodeSharedPrefs);
-    //_logs.info(message: "deviceSharedPrefs data type: ${sinkNodeSharedPrefs.runtimeType}");
-    /*extractSensorNodes(sensorNodeList: devices);*/
-
-
-   /* for(int i=0; i < _sensorNodeList.length; i++) {
-      SensorNodeSnapshot? snSnapshot = await DatabaseHelper.getAllReadings(_sensorNodeList[i].deviceID);
-      _sensorNodeSnapshotList.add(snSnapshot);
-      _logs.info(message: 'snSnapshot :${snSnapshot?.deviceID}');
-    }*/
-    //_logs.info(message: 'devices shared prefs init: $sinkNodeSharedPrefs');
-    /*listenToStream();*/
-
+    await _setDeviceListFromApi(userData: userData, tokens: tokens);
     notifyListeners();
-    _logs.success(message: 'init() done');
-  }
-  
-  void _setStreamControllers({
-    required seSnapshotStreamController,
-    required alertsStreamController,
-    required mqttStreamController}) {
-    
-    _seSnapshotStreamController = seSnapshotStreamController;
-    _alertsStreamController = alertsStreamController;
-    _mqttStreamController = mqttStreamController;
   }
 
   // maps the payload from sensor devices
@@ -270,8 +199,6 @@ class DevicesProvider extends ChangeNotifier {
     _logs.info(message: "sensorNodeAlerts running");
 
     List<Map<String, dynamic>>? alertDataSharedPrefs = await _sharedPrefsUtils.getAlertsData();
-
-
     alertDataSharedPrefs ??= [];
 
     alertDataSharedPrefs.removeWhere((alert) {
@@ -304,10 +231,11 @@ class DevicesProvider extends ChangeNotifier {
   Future<void> sinkNameChange(Map<String,dynamic> updatedSinkData) async {
     _logs.info(message: "sinkNameChange running....");
 
-    if(!_sinkNodeList.any((sink) => sink.deviceID == updatedSinkData['deviceID'])){
+    if(_sinkNodeMap[updatedSinkData['deviceId']] == null){
       //TODO: Error Handle
       return;
     }
+
     _logs.info(message: "getSKList running ....");
     List<Map<String,dynamic>>? _getSKList = await _sharedPrefsUtils.getSKList();
     _logs.info(message: "sharedPrefsUtils : ${_sharedPrefsUtils.getSKList}");
@@ -332,11 +260,7 @@ class DevicesProvider extends ChangeNotifier {
     bool success = await _sharedPrefsUtils.setSKList(sinkList: _getSKList);
     if(success){
       SinkNode updatedSink = SinkNode.fromJSON(updatedSinkData);
-      SinkNode _oldSinkNode = _sinkNodeList.where((sink) => sink.deviceID == updatedSink.deviceID).first;
-      int index = _sinkNodeList.indexOf(_oldSinkNode);
-      _sinkNodeList.remove(_sinkNodeList.where((sink) => sink.deviceID == updatedSink.deviceID).first);
-      _sinkNodeList.insert(index, updatedSink);
-      _logs.info(message: 'provider $success');
+      _sinkNodeMap[updatedSink.deviceID] = updatedSink;
       notifyListeners();
     }else{
       _logs.error(message: "Sipyat");
@@ -346,10 +270,12 @@ class DevicesProvider extends ChangeNotifier {
 
   Future<void> sensorNameChange(Map<String,dynamic> updatedData) async {
     _logs.info(message: "sensorNameChange : $updatedData");
-    if(!_sensorNodeList.any((sensor) => sensor.deviceID == updatedData['deviceID'])){
+
+    if(_sensorNodeMap[updatedData['deviceID']] == null){
       ///TODO: Error Handle
       return;
     }
+
     List<Map<String,dynamic>>? getSNList = await _sharedPrefsUtils.getSNList();
 
     if(getSNList == null || getSNList.isEmpty){
@@ -367,37 +293,12 @@ class DevicesProvider extends ChangeNotifier {
     bool success = await _sharedPrefsUtils.setSNList(sensorList: getSNList);
     if(success){
       SensorNode updatedSensor = SensorNode.fromJSON(updatedData);
-      SensorNode _oldSensor = _sensorNodeList.where((sensor) => sensor.deviceID == updatedSensor.deviceID).first;
-      int index = _sensorNodeList.indexOf(_oldSensor);
-      _sensorNodeList.remove(_sensorNodeList.where((sensor) => sensor.deviceID == updatedSensor.deviceID).first);
-      _sensorNodeList.insert(index, updatedSensor);
+      _sensorNodeMap[updatedSensor.deviceID] = updatedSensor;
       notifyListeners();
     }else{
       _logs.error(message: "err: sensor node dev provider sensorNameChange");
     }
     notifyListeners();
   }
-
-  ///Extract Sensor Node
-  /*void extractSensorNodes({required List <Map<String, dynamic>> sensorNodeList}) {
-    List<Map<String,dynamic>> sensorNodes = [];
-
-    for(var device in sensorNodeList){
-      _logs.info(message: 'registeredSensorNodes type: ${device['registeredSensorNodes'].runtimeType}');
-      if (device.containsKey('registeredSensorNodes')){
-        List <Map<String,dynamic>> snList = device['registeredSensorNodes'];
-        for (var sensorNode in snList){
-          Map<String,dynamic> sensorNodeData = {
-            'deviceID' : sensorNode['SNID'],
-            'name' : sensorNode['SensorNode_Name'],
-            'sinkNodeID' :device['SKID'],
-          };
-          sensorNodes.add(sensorNodeData);
-        }
-      }
-    }
-    _logs.info(message: sensorNodes.toString());
-    _sharedPrefsUtils.setSNList(sensorList: sensorNodes);
-  }*/
 
 }

--- a/lib/providers/mqtt_provider.dart
+++ b/lib/providers/mqtt_provider.dart
@@ -38,7 +38,6 @@ class MqttProvider extends ChangeNotifier {
   /// Returns the MqttClient
   Future<Exception?> initClient({
     required String clientIdentifier,
-    required StreamController<String> streamController,
     String? host,
     int? port,
     int? keepAlivePeriod,

--- a/lib/providers/mqtt_provider.dart
+++ b/lib/providers/mqtt_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:mqtt_client/mqtt_client.dart';
 import 'package:mqtt_client/mqtt_server_client.dart';
@@ -22,6 +24,7 @@ class MqttProvider extends ChangeNotifier {
   /// Returns the MqttClient
   Future<Exception?> initClient({
     required String clientIdentifier,
+    required StreamController<String> streamController,
     String? host,
     int? port,
     int? keepAlivePeriod,
@@ -45,6 +48,12 @@ class MqttProvider extends ChangeNotifier {
       _logs.success(message: 'mqtt client init done...');
     }
     _mqttConnectionState = mqttConnect.$1.connectionStatus!.state;
+
+    mqttConnect.$1.updates!.listen((messages) {
+      final MqttPublishMessage recMes = messages[0] as MqttPublishMessage;
+      final String payload = MqttPublishPayload.bytesToStringAsString(recMes.payload.message);
+      streamController.add(payload);
+    });
 
     notifyListeners();
     return mqttConnect.$2;

--- a/lib/services/devices_services.dart
+++ b/lib/services/devices_services.dart
@@ -40,11 +40,11 @@ class DevicesServices {
       _logs.error(message:'data received from ApiRequest().get() contains error or invalid value: ${data.values}');
     } else {
       List<dynamic> sinkNodesUnparsed = data['data'];
-      List<Map<String, dynamic>> sensorNodesParsed = [];
 
       // parse devices
       for (var sinkUnparsed in sinkNodesUnparsed) {
         List<dynamic> sensorNodesUnparsed = sinkUnparsed['sensor_nodes'];
+        List<Map<String, dynamic>> sensorNodesParsed = [];
         for (var sensorUnparsed in sensorNodesUnparsed) {
           sensorNodesParsed.add({
             'device_id': sensorUnparsed['device_id'],

--- a/lib/services/devices_services.dart
+++ b/lib/services/devices_services.dart
@@ -43,9 +43,7 @@ class DevicesServices {
         headers: {'Authorization': 'Bearer $token', 'UID': userID});
 
     if (data.containsKey('error') || data.isEmpty || data['data'] == null) {
-      _logs.error(
-          message:
-              'data received from ApiRequest().get() contains error or invalid value: ${data.values}');
+      _logs.error(message:'data received from ApiRequest().get() contains error or invalid value: ${data.values}');
       throw Exception('unhandled error on DevicesServices().getDevices()');
     }
 

--- a/lib/services/devices_services.dart
+++ b/lib/services/devices_services.dart
@@ -13,8 +13,7 @@ part 'devices/sensor_data.dart';
 part 'devices/sink_data.dart';
 
 class DevicesServices {
-  final _SensorNodeDataServices _sensorNodeDataServices =
-      _SensorNodeDataServices();
+  final _SensorNodeDataServices _sensorNodeDataServices =_SensorNodeDataServices();
   final _SinkNodeDataServices _sinkNodeDataServices = _SinkNodeDataServices();
 
   // dependencies
@@ -26,56 +25,46 @@ class DevicesServices {
   final Logs _logs = Logs(tag: 'DevicesServices()');
 
   /// Retrieves all devices registered to the user, requires the user id
-  Future<List<Map<String, dynamic>>> getDevices({required String userID, required String token}) async {
-    String? accessToken;
-    TokenStatus accessStatus = await _authUtils.verifyToken(token: token);
-
-    if (accessStatus != TokenStatus.valid) {
-      Map<String, dynamic> refresh =
-          await _sharedPrefsUtils.getTokens(refresh: true);
-      accessToken =
-          await _authUtils.refreshAccessToken(refresh: refresh['refresh']);
-      await _authProvider.setAccess(access: accessToken!);
-    }
-
-    final Map<String, dynamic> data = await _apiRequest.get(
-        route: _apiRoutes.getDevices,
-        headers: {'Authorization': 'Bearer $token', 'UID': userID});
-
-    if (data.containsKey('error') || data.isEmpty || data['data'] == null) {
-      _logs.error(message:'data received from ApiRequest().get() contains error or invalid value: ${data.values}');
-      throw Exception('unhandled error on DevicesServices().getDevices()');
-    }
-
-    _logs.info(message: data['data'].toString());
-
-    List<dynamic> sinkNodesUnparsed = data['data'];
+  Future<List<Map<String, dynamic>>?> getDevices({
+    required String userID,
+    required String token}) async {
 
     List<Map<String, dynamic>> sinkNodesParsed = [];
 
-    // parse devices
-    for (int i = 0; i < sinkNodesUnparsed.length; i++) {
-      List<dynamic> sensorNodesUnparsed = sinkNodesUnparsed[i]['sensor_nodes'];
+    final Map<String, dynamic> data = await _apiRequest.get(
+        route: _apiRoutes.getDevices,
+        headers: {'Authorization': 'Bearer $token', 'UID': userID}
+    );
+
+    if (data.containsKey('error') || data.isEmpty || data['data'] == null) {
+      _logs.error(message:'data received from ApiRequest().get() contains error or invalid value: ${data.values}');
+    } else {
+      List<dynamic> sinkNodesUnparsed = data['data'];
       List<Map<String, dynamic>> sensorNodesParsed = [];
-      for (int x = 0; x < sensorNodesUnparsed.length; x++) {
-        sensorNodesParsed.add({
-          'device_id': sensorNodesUnparsed[x]['device_id'],
-          'name': sensorNodesUnparsed[x]['name'],
-          'latitude' : sensorNodesUnparsed[x]['latitude'],
-          'longitude' : sensorNodesUnparsed[x]['longitude'],
+
+      // parse devices
+      for (var sinkUnparsed in sinkNodesUnparsed) {
+        List<dynamic> sensorNodesUnparsed = sinkUnparsed['sensor_nodes'];
+        for (var sensorUnparsed in sensorNodesUnparsed) {
+          sensorNodesParsed.add({
+            'device_id': sensorUnparsed['device_id'],
+            'name': sensorUnparsed['name'],
+            'latitude' : sensorUnparsed['latitude'],
+            'longitude' : sensorUnparsed['longitude'],
+          });
+        }
+        sinkNodesParsed.add({
+          'device_id': sinkUnparsed['device_id'],
+          'name': sinkUnparsed['name'],
+          'latitude' : sinkUnparsed['latitude'],
+          'longitude' : sinkUnparsed['longitude'],
+          'sensor_nodes': sensorNodesParsed
         });
       }
-      sinkNodesParsed.add({
-        'device_id': sinkNodesUnparsed[i]['device_id'],
-        'name': sinkNodesUnparsed[i]['name'],
-        'latitude' : sinkNodesUnparsed[i]['latitude'],
-        'longitude' : sinkNodesUnparsed[i]['longitude'],
-        'sensor_nodes': sensorNodesParsed
-      });
     }
 
     // type: List<Map<String, dynamic>>
-    return sinkNodesParsed;
+    return sinkNodesParsed.isNotEmpty ? sinkNodesParsed : null;
   }
 
   /// Returns sensor node snapshot data (`deviceID`, `timestamp`, `soilMoisture`, `temperature`, `humidity`, `batteryLevel`)

--- a/lib/sqlitedb/db.dart
+++ b/lib/sqlitedb/db.dart
@@ -4,6 +4,9 @@ import 'package:path/path.dart';
 import 'package:smmic/models/device_data_models.dart';
 
 class DatabaseHelper {
+  // dependencies
+  final Logs _logs = Logs(tag: 'DatabaseHelper');
+
   static const int _version = 1;
   static const String dbName = "Readings.db";
 
@@ -77,21 +80,19 @@ class DatabaseHelper {
   
   
   static Future<List<SensorNodeSnapshot>?>chartReadings(String deviceID) async {
-    print('chartReadings Initialized');
     final db = await _getDB();
     
-    final List<Map<String,dynamic>> chartReadings = await db.query(
+    final List<Map<String,dynamic>> queryResult = await db.query(
       "SMSensorReadings",
       where: 'device_id = ?',
       whereArgs: [deviceID],
       orderBy: 'timestamp DESC',
-      limit: 4,
+      limit: 6,
     );
 
-    final readings = chartReadings.map((data) => SensorNodeSnapshot.fromJSON(data)).toList().reversed.toList();
+    final readings = queryResult.map((data) => SensorNodeSnapshot.fromJSON(data)).toList().reversed.toList();
 
-
-    print(readings.reversed);
+    Logs(tag: 'DatabaseHelper.chartReadings()').info(message: '$readings');
     return readings;
   }
 }

--- a/lib/subcomponents/devices/device_dialog.dart
+++ b/lib/subcomponents/devices/device_dialog.dart
@@ -37,15 +37,14 @@ class DeviceDialog{
               }, child: const Text("Cancel")
               ),
               TextButton(onPressed: () async {
-                UserAccess? _userAccess = context.read<AuthProvider>().accessData;
-                List <SinkNode>? _sinkNodeList = context.read<DevicesProvider>().sinkNodeList;
-                if(_userAccess == null) {
+                UserAccess? userAccess = context.read<AuthProvider>().accessData;
+                SinkNode? sinkNode = context.read<DevicesProvider>().sinkNodeMap[deviceID];
+                if(userAccess == null) {
                   context.read<AuthProvider>().accessStatus == TokenStatus.forceLogin;
                   _globalNavigator.forceLoginDialog();
                 }else{
-                  if(_sinkNodeList == null) {
+                  if(sinkNode == null) {
                     //TODO: implement a proper null handle in case _sinkNode == null
-                    print('sink node list is null: $_sinkNodeList');
                     return;
                   }else{
                     Map<String,dynamic> skDataProvider = {
@@ -53,7 +52,7 @@ class DeviceDialog{
                       'deviceName' : sinkNameController.text,
                       'latitude' : latitude,
                       'longitude' : longitude,
-                      "registeredSensorNodes" : context.read<DevicesProvider>().sinkNodeList.where((sink) => sink.deviceID == deviceID).first.registeredSensorNodes
+                      "registeredSensorNodes" : sinkNode.registeredSensorNodes
                     };
 
                     Map<String,dynamic> skData = {
@@ -62,7 +61,7 @@ class DeviceDialog{
                       'latitude' : latitude,
                       'longitude' : longitude
                     };
-                    await _devicesServices.updateSKDeviceName(token: _userAccess.token, deviceID: deviceID, sinkName: skData);
+                    await _devicesServices.updateSKDeviceName(token: userAccess.token, deviceID: deviceID, sinkName: skData);
 
                     if(context.mounted){
                       context.read<DevicesProvider>().sinkNameChange(skDataProvider);
@@ -97,16 +96,16 @@ class DeviceDialog{
               }, child: const Text("Cancel")),
               TextButton(onPressed: () async {
                 UserAccess? userAccess = context.read<AuthProvider>().accessData;
-                List<SensorNode>? sensorNodeList = context.read<DevicesProvider>().sensorNodeList;
+                SensorNode? sensorNode = context.read<DevicesProvider>().sensorNodeMap[deviceID];
 
                 if(userAccess == null){
                   context.read<AuthProvider>().accessStatus == TokenStatus.forceLogin;
                   _globalNavigator.forceLoginDialog();
                 }else{
-                  if(sensorNodeList == null){
-                    print("sensor node device dialog null : $sensorNodeList");
+                  if(sensorNode == null){
+                    return;
                   }else{
-                    String registerSinkNodeID = context.read<DevicesProvider>().sensorNodeList.where((sensor) => sensor.deviceID == deviceID).first.registeredSinkNode;
+                    String registerSinkNodeID = sensorNode.registeredSinkNode;
                     Map<String,dynamic> snDataProvider = {
                       'deviceID' : deviceID,
                       'deviceName' : sensorNameController.text,

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -154,7 +154,6 @@ class ApiRequest {
 
   void connectSeReadingsChannel({
     required String route,
-    required StreamController? streamController,
     required BuildContext context}) {
 
     WebSocketChannel? channel;
@@ -191,7 +190,6 @@ class ApiRequest {
 
   void connectAlertsChannel ({
     required String route,
-    required StreamController? streamController,
     required BuildContext context}) {
 
     WebSocketChannel? channel;

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dartz/dartz.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -20,299 +21,198 @@ class ApiRequest {
   // dependencies / helpers
   final ApiRoutes _apiRoutes = ApiRoutes();
 
-  /// Get request for api, returns a the response status code and the body if available
-  Future<dynamic> get(
-      {required String route, Map<String, String>? headers}) async {
+  Future<Map<String, dynamic>> _request({
+    required String route,
+    required Either<
+      Future<http.Response>Function(Uri, {Object? body, Encoding? encoding, Map<String, String>? headers}),
+      Future<http.Response>Function(Uri, {Map<String, String>? headers})>
+    method,
+    Map<String, String>? headers,
+    Object? body}) async {
+
+    http.Response? res;
+    int? statusCode;
+    String? resBody;
+
+    Map<String, dynamic> finalRes = {};
+
     try {
-      _logs.info(message: 'get() $route, headers: ${headers ?? 'none'}');
-      final response = await http.get(Uri.parse(route), headers: headers);
-      if (response.statusCode == 500) {
-        _logs.error(
-            message:
-                'get() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': {'err': 'internal server error (code 500)'}
-        };
-      } else if (response.statusCode == 400) {
-        _logs.warning(
-            message:
-                'post() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      } else if (response.statusCode == 401) {
-        _logs.warning(
-            message:
-                'post() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
+      res = await method.fold(
+          (method1) => method1(
+              Uri.parse(route),
+              headers: headers,
+              body: body),
+          (method2) => method2(
+            Uri.parse(route),
+            headers: headers)
+      );
+
+      if (res == null) {
+        throw Exception('unhandled unexpected error -> request result null');
       }
-      if (response.statusCode == 200) {
-        _logs.success(
-            message:
-                'post() $route, returned with data ${response.statusCode}');
-        return {'code': response.statusCode, 'data': jsonDecode(response.body)};
+
+      statusCode = res.statusCode;
+      resBody = res.body;
+
+      switch (statusCode) {
+        case (500):
+          _logs.error(message:'post() $route, returned with error $statusCode');
+          finalRes.addAll({'error' : statusCode});
+        case (400):
+          _logs.warning(message:'post() $route, returned with error $statusCode');
+          finalRes.addAll({'error' : statusCode});
+        case (401):
+          _logs.warning(message:'post() $route, returned with error $statusCode');
+          finalRes.addAll({'error' : statusCode});
+        case (200):
+          _logs.success(message:'post() $route, returned with data $statusCode');
+          finalRes.addAll({
+            'status_code': statusCode,
+            'body': resBody,
+            'data': jsonDecode(resBody)
+          });
       }
+    } on http.ClientException catch (e) {
+      _logs.warning(message: 'post() raised ClientException -> $e');
     } catch (e) {
-      return {'error': e};
+      _logs.warning(message:'post() unhandled unexpected post() error (statusCode: $statusCode, body: $resBody)');
     }
-    return {'error': 'unhandled unexpected get() error'};
+
+    return finalRes;
   }
 
-  Future<Map<String, dynamic>> post(
-      {required String route,
-      Map<String, String>? headers,
-      Object? body}) async {
-    _logs.info(
-        message: 'post() -> route: $route, headers: $headers, body: $body');
-    http.Response? response;
-    try {
-      response =
-          await http.post(Uri.parse(route), headers: headers, body: body);
-      if (response.statusCode == 500) {
-        _logs.error(
-            message:
-                'post() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': {'err': 'internal server error (code 500)'}
-        };
-      } else if (response.statusCode == 400) {
-        _logs.warning(
-            message:
-                'post() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      } else if (response.statusCode == 401) {
-        _logs.warning(
-            message:
-                'post() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      }
-      if (response.statusCode == 200) {
-        _logs.success(
-            message:
-                'post() $route, returned with data ${response.statusCode}');
-        return {
-          'success': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      }
-    } catch (e) {
-      throw Exception(e);
-    }
-    _logs.warning(
-        message:
-            'post() unhandled unexpected post() error (statusCode: ${response.statusCode}, body: ${response.body})');
-    return {
-      'error': 'unhandled unexpected post() error',
-      'status_code': response.statusCode,
-      'body': response.body
-    };
+  /// Get request for api, returns a the response status code and the body if available
+  Future<dynamic> get({
+    required String route,
+    Map<String,String>? headers }) async {
+
+    _logs.info(message: 'get() $route, headers: ${headers ?? 'none'}');
+
+    Map<String, dynamic> result = await _request(
+        route: route,
+        method: right(http.get),
+        headers: headers,
+    );
+
+    return result;
+  }
+
+  Future<Map<String, dynamic>> post({
+    required String route,
+    Map<String, String>? headers,
+    Object? body }) async {
+
+    _logs.info(message: 'post() -> route: $route, headers: $headers, body: $body');
+
+    Map<String, dynamic> result = await _request(
+        route: route,
+        method: left(http.post),
+        headers: headers,
+        body: body
+    );
+
+    return result;
   }
 
   Future<Map<String, dynamic>> put(
       {required String route,
       Map<String, String>? headers,
       Object? body}) async {
-    try {
-      _logs.info(
-          message:
-              'put() $route, headers: ${headers ?? 'none'}, body: ${body ?? 'none'}');
-      final response =
-          await http.put(Uri.parse(route), headers: headers, body: body);
-      if (response.statusCode == 500) {
-        _logs.error(
-            message:
-                'put() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': {'err': 'internal server error (code 500)'}
-        };
-      } else if (response.statusCode == 400) {
-        _logs.warning(
-            message:
-                'put() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      } else if (response.statusCode == 401) {
-        _logs.warning(
-            message:
-                'put() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      }
-      if (response.statusCode == 200) {
-        _logs.success(
-            message: 'put() $route, returned with data ${response.statusCode}');
-        return {
-          'success': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      }
-    } catch (e) {
-      throw Exception(e);
-    }
-    return {'error': 'unhandled unexpected put() error'};
+
+    _logs.info(
+        message:
+          'put() $route, headers: ${headers ?? 'none'}, body: ${body ?? 'none'}');
+
+    Map<String, dynamic> result = await _request(
+        route: route,
+        method: left(http.put),
+        headers: headers,
+        body: body
+    );
+
+    return result;
   }
 
   Future<Map<String, dynamic>> patch(
       {required String route,
       Map<String, String>? headers,
       Object? body}) async {
-    try {
-      _logs.info(
-          message:
-              'patch() $route, headers: ${headers ?? 'none'}, body: ${body ?? 'none'}');
-      final response =
-          await http.patch(Uri.parse(route), headers: headers, body: body);
-      if (response.statusCode == 500) {
-        _logs.error(
-            message:
-                'patch() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': {'err': 'internal server error (code 500)'}
-        };
-      } else if (response.statusCode == 400) {
-        _logs.warning(
-            message:
-                'patch() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      } else if (response.statusCode == 401) {
-        _logs.warning(
-            message:
-                'patch() $route, returned with error ${response.statusCode}');
-        return {
-          'error': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      }
-      if (response.statusCode == 200) {
-        _logs.success(
-            message:
-                'patch() $route, returned with data ${response.statusCode}');
-        return {
-          'success': response.statusCode,
-          'data': jsonDecode(response.body)
-        };
-      }
-    } catch (e) {
-      throw Exception(e);
-    }
-    return {'error': 'unhandled unexpected patch() error'};
+
+    _logs.info(
+        message:
+          'put() $route, headers: ${headers ?? 'none'}, body: ${body ?? 'none'}');
+
+    Map<String, dynamic> result = await _request(
+        route: route,
+        method: left(http.patch),
+        headers: headers,
+        body: body
+    );
+
+    return result;
   }
 
-  void channelConnect({required String route, Map<String, String>? headers, Object? body, required StreamController controller, required String deviceID}) {
-    try {
-      _logs.info(message: "channelConnect initializing");
-      final channel = WebSocketChannel.connect(Uri.parse(route));
-      _logs.info(message: 'stream response: ${channel.stream}');
-      channel.stream.listen((data) async {
-        _logs.info(message: 'stream data type: ${data.runtimeType}');
-        final Map<String, dynamic> decodedData = jsonDecode(data);
-        _logs.info(message: 'decoded data: $decodedData');
-        
-        if (decodedData['message']['device_id'] == deviceID) {
-          _logs.info(message: 'if statement for device_id == deviceID $deviceID');
-          final Map<String, dynamic> messageData = decodedData['message'];
-          _logs.info(message: 'message data: $messageData');
-          final SensorNodeSnapshot mappedData = SensorNodeSnapshot.fromJSON(messageData);
-          _logs.info(message: 'Mapped Data: $mappedData');
-          _logs.info(message: 'Adding Mapped Data to SQFLITE');
-          DatabaseHelper.addReadings(mappedData);
-          _logs.info(message: 'Checking if $deviceID sqlite readings record reached limit');
-          DatabaseHelper.readingsLimit(deviceID);
-          controller.add(mappedData);
-          await Future<void>.delayed(const Duration(seconds: 4));
-        }else{
-          _logs.info(message: "device ID not matched skipping");
-        }
-      });
-    } catch (e) {
-      _logs.error(message: 'Failed to connect to websocket');
-      _logs.error(message: '$e');
-      throw Exception(e);
-    }
-    return;
-  }
-
-  WebSocketChannel snReadingsChannel({
+  WebSocketChannel? connectSeReadingsChannel({
     required String route,
     required StreamController streamController}) {
+
+    WebSocketChannel? channel;
     // initialize channel
-    final WebSocketChannel channel = WebSocketChannel.connect(Uri.parse(route));
+    channel = WebSocketChannel.connect(Uri.parse(route));
     // add listener
-    channel.stream.listen((data) {
-      final Map<String, dynamic> decodedData = jsonDecode(data);
-      final SensorNodeSnapshot snapshotObj = SensorNodeSnapshot.fromJSON(decodedData['message']);
-      DatabaseHelper.addReadings(snapshotObj);
-      DatabaseHelper.readingsLimit(snapshotObj.deviceID);
-      // pass to stream controller
-      streamController.add(snapshotObj);
-      _logs.info(message: 'snapshotObj sent added to snReadingsStreamController -> ${snapshotObj.toString()}');
-    });
+    try{
+      channel = WebSocketChannel.connect(Uri.parse(route));
+      channel.stream.listen(
+        (data) {
+          final Map<String, dynamic> decodedData = jsonDecode(data);
+          final SensorNodeSnapshot snapshotObj = SensorNodeSnapshot.fromJSON(decodedData['message']);
+          DatabaseHelper.addReadings(snapshotObj);
+          DatabaseHelper.readingsLimit(snapshotObj.deviceID);
+          // pass to stream controller
+          streamController.add(snapshotObj);
+          _logs.info(message: 'snapshotObj sent added to snReadingsStreamController -> ${snapshotObj.toString()}');
+        }, onError: (err) {
+          _logs.warning(message: 'connectSeReadingsChannel() error in stream.listen -> $err');
+        }
+      );
+    } on WebSocketChannelException catch (e) {
+      _logs.warning(message: 'connectSeReadingsChannel() called WebSocketChannelException -> $e');
+    } on Exception catch (e) {
+      _logs.warning(message: 'connectSeReadingsChannel() unhandled unexpected exception raised -> $e');
+    }
+
     // return channel instance
     return channel;
   }
 
-  void channelReadings({required String route, required StreamController controller, required String deviceID, required BuildContext context}){
-    try{
-      final channel = WebSocketChannel.connect(Uri.parse(route));
-      channel.stream.listen((data){
-        final Map<String,dynamic> decodedData = jsonDecode(data);
-        _logs.info(message: 'alerts decoded: $decodedData');
-        if(decodedData['message']['device_id'] == deviceID){
-          final Map<String,dynamic> messageData = decodedData['message'];
-          _logs.info(message: 'alerts message data: $messageData');
-          _logs.info(message: 'alerts data jsonfield: ${messageData['data']['soil_moisture']}');
-          DatabaseHelper.addReadings(SensorNodeSnapshot.fromJSON(messageData));
-          _logs.info(message: 'Checking if $deviceID sqlite readings record reached limit');
-          DatabaseHelper.readingsLimit(deviceID);
-          final SMAlerts mappedData = SMAlerts.fromJSON(messageData);
-          context.read<DevicesProvider>().sensorNodeAlerts(alertMessage: mappedData);
-          _logs.info(message: 'alerts mapped data: ${mappedData.data['soil_moisture']}');
-          controller.add(mappedData);
-        }else{
-          _logs.info(message: 'deviceID not matching');
-        }
-      });
-    }catch(e){
-      throw Exception(e);
-    }
-    return;
-  }
-
-  WebSocketChannel alertsChannel ({
+  WebSocketChannel? connectAlertsChannel ({
     required String route,
     required StreamController streamController}) {
+    
+    WebSocketChannel? channel;
     // initialize channel
-    final WebSocketChannel channel = WebSocketChannel.connect(Uri.parse(route));
-    // add listener
-    channel.stream.listen((data){
-      final Map<String,dynamic> decodedData = jsonDecode(data);
-      DatabaseHelper.addReadings(SensorNodeSnapshot.fromJSON(decodedData['message']));
-      // alert object
-      final SMAlerts alertObj = SMAlerts.fromJSON(decodedData['message']);
-      streamController.add(alertObj);
-      _logs.info(message: 'alertObject sent added to alertStreamController -> ${alertObj.toString()}');
-    });
+    try {
+      channel = WebSocketChannel.connect(Uri.parse(route));
+      channel.stream.listen(
+        (data){
+          final Map<String,dynamic> decodedData = jsonDecode(data);
+          final SensorNodeSnapshot snapshotObj = SensorNodeSnapshot.fromJSON(decodedData['message']);
+          DatabaseHelper.addReadings(snapshotObj);
+          DatabaseHelper.readingsLimit(snapshotObj.deviceID);
+          // alert object
+          final SMAlerts alertObj = SMAlerts.fromJSON(decodedData['message']);
+          streamController.add(alertObj);
+          _logs.info(message: 'alertObject sent added to alertStreamController -> ${alertObj.toString()}');
+        }, onError: (err) {
+          _logs.warning(message: 'connectAlertsChannel() error in stream.listen -> $err');
+        }
+      );
+    } on WebSocketChannelException catch (e) {
+      _logs.warning(message: 'connectAlertsChannel() called WebSocketChannelException -> $e');
+    } on Exception catch (e) {
+      _logs.warning(message: 'connectAlertsChannel() unhandled unexpected exception raised -> $e');
+    }
+
     // return channel instance
     return channel;
   }

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -21,6 +21,9 @@ class ApiRequest {
   // dependencies / helpers
   final ApiRoutes _apiRoutes = ApiRoutes();
 
+  WebSocketChannel? _seReadingsWsChannel;
+  WebSocketChannel? _alertsWsChannel;
+
   Future<Map<String, dynamic>> _request({
     required String route,
     required Either<
@@ -185,7 +188,17 @@ class ApiRequest {
         _logs.warning(message: 'Listener attached to WebSocketChannel');
       }, onError: (err) {
         _logs.warning(message: 'connectAlertsChannel() error in stream.listen : $route -> $err');
+    }, onDone: () {
+      channel!.sink.close();
     });
+
+    return;
+  }
+
+  void disconnectSeReadingsWs() {
+    if (_seReadingsWsChannel != null) {
+      _seReadingsWsChannel!.sink.close();
+    }
   }
 
   void connectAlertsChannel ({
@@ -223,6 +236,16 @@ class ApiRequest {
         }
       }, onError: (err) {
         _logs.warning(message: 'connectAlertsChannel() error in stream.listen : $route -> $err');
+    }, onDone: () {
+        channel!.sink.close();
     });
+
+    return;
+  }
+
+  void disconnectAlertsWs() {
+    if (_alertsWsChannel != null) {
+      _alertsWsChannel!.sink.close();
+    }
   }
 }

--- a/lib/utils/datetime_formatting.dart
+++ b/lib/utils/datetime_formatting.dart
@@ -10,9 +10,9 @@ class DateTimeFormatting {
   }
 
   String formatTimeClearZero(DateTime dateTime) {
-    if(DateFormat('HH:mm').format(dateTime)[0] == '0'){
-      return DateFormat('HH:mm').format(dateTime).substring(1, DateFormat('HH:mm').format(dateTime).length);
-    }
+    // if(DateFormat('HH:mm').format(dateTime)[0] == '0'){
+    //   return DateFormat('HH:mm:ss.SSS').format(dateTime).substring(1, DateFormat('HH:mm').format(dateTime).length);
+    // }
     return DateFormat('HH:mm:ss.SSS').format(dateTime);
   }
 

--- a/lib/utils/device_utils.dart
+++ b/lib/utils/device_utils.dart
@@ -13,66 +13,24 @@ class DeviceUtils {
       sensorNodeIDList.add((sensorNodes[i]['device_id']).toString());
     }
     Map<String, dynamic> sinkNodeMap = {
-      'deviceID': sinkMap['device_id'],
-      'deviceName': sinkMap['name'],
-      'latitude' : sinkMap['latitude'],
-      'longitude' : sinkMap['longitude'],
-      'registeredSensorNodes': sensorNodeIDList
+      SinkNodeKeys.deviceID.key : sinkMap[SinkNodeKeys.deviceID.key],
+      SinkNodeKeys.deviceName.key : sinkMap[SinkNodeKeys.deviceName.key],
+      SinkNodeKeys.latitude.key : sinkMap[SinkNodeKeys.latitude.key],
+      SinkNodeKeys.longitude.key : sinkMap[SinkNodeKeys.longitude.key],
+      SinkNodeKeys.registeredSensorNodes.key : sensorNodeIDList
     };
     return SinkNode.fromJSON(sinkNodeMap);
-  }
-
-  Map<String,dynamic> mapSinkNode(Map<String, dynamic> sinkMap){
-    List<Map<String, dynamic>> sensorNodes = sinkMap['sensor_nodes'];
-    List<String> sensorNodeIDList = [];
-    for (int i = 0; i < sensorNodes.length; i++){
-      sensorNodeIDList.add((sensorNodes[i]['device_id']).toString());
-    }
-    Map<String, dynamic> sinkNodeMap = {
-      'deviceID': sinkMap['device_id'],
-      'deviceName': sinkMap['name'],
-      'latitude' : sinkMap['latitude'],
-      'longitude' : sinkMap['longitude'],
-      'registeredSensorNodes': sensorNodeIDList
-    };
-    return sinkNodeMap;
   }
 
   /// Helper function to map a sensor node map into an object
   SensorNode sensorNodeMapToObject({required Map<String, dynamic> sensorMap, required String sinkNodeID}){
     Map<String, dynamic> sensorNodeMap = {
-      'deviceID': sensorMap['device_id'],
-      'deviceName': sensorMap['name'],
-      'latitude': sensorMap['latitude'],
-      'longitude':sensorMap['longitude'],
-      'sinkNodeID': sinkNodeID
+      SensorNodeKeys.deviceID.key : sensorMap['device_id'],
+      SensorNodeKeys.deviceName.key: sensorMap['name'],
+      SensorNodeKeys.latitude.key : sensorMap['latitude'],
+      SensorNodeKeys.longitude.key :sensorMap['longitude'],
+      SensorNodeKeys.sinkNode.key : sinkNodeID
     };
     return SensorNode.fromJSON(sensorNodeMap);
   }
-
-  Map<String,dynamic> mapSensorNode(Map<String, dynamic> sensorMap, String sinkNodeID){
-    Map<String,dynamic> sinkNodeMap = {};
-    try{
-      sinkNodeMap = {
-        'deviceID': sensorMap['device_id'],
-        'deviceName': sensorMap['name'],
-        'latitude': sensorMap['latitude'],
-        'longitude': sensorMap['longitude'],
-        'sinkNodeID': sinkNodeID
-
-      };
-    }catch(e){
-      _logs.info(message: e.toString());
-    }
-    return sinkNodeMap;
-  }
-
- /* Map<String,dynamic> mapSNReadings(String message){
-     message.replaceAll('{', '');
-     message.replaceAll('}', '');
-     for(int i = 0; i < message.allMatches("{").toList().length; i++){
-       message.replaceAll(from, replace)
-     }
-  }*/
-
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dartz:
+    dependency: "direct main"
+    description:
+      name: dartz
+      sha256: e6acf34ad2e31b1eb00948692468c30ab48ac8250e0f0df661e29f12dd252168
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   email_validator:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   mobile_scanner: ^6.0.2
   qr_scanner_overlay: ^0.0.2
   qr_flutter: ^4.1.0
+  dartz: ^0.10.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
devices
- widgets that display device data now listen to providers instead of streams
- updated some helper functions
- set key enums in device data models to keep keys consistent

mqtt
- mqtt provider init in main.dart
- mqtt now able to update device data from payload
- follows the same state management pattern as websockets

websocket connections
- websocket connections initialize in the authgate and register the context alongside them so that regardless of where the context is down the widget tree, dependents are updated

others
- added dynamic serializer static function to SensorNodeSnapshot