### PR TITLE
tokens, devices provider, api, websocket connection managers

### DIFF
--- a/lib/components/devices/cards/sensor_node_card.dart
+++ b/lib/components/devices/cards/sensor_node_card.dart
@@ -36,14 +36,14 @@ class _SensorNodeCardState extends State<SensorNodeCard> {
   final Logs _logs = Logs(tag: 'Sensor Node Card()');
 
   final StreamController<SensorNodeSnapshot> _snapshotStreamController = StreamController<SensorNodeSnapshot>.broadcast();
-  final StreamController<SMAlerts> _alertsStreamController = StreamController<SMAlerts>.broadcast();
+  final StreamController<SensorAlerts> _alertsStreamController = StreamController<SensorAlerts>.broadcast();
 
-  StreamController<SMAlerts> get smStreamController => _alertsStreamController;
+  StreamController<SensorAlerts> get smStreamController => _alertsStreamController;
   StreamController<SensorNodeSnapshot> get streamController => _snapshotStreamController;
 
   SensorNodeSnapshot? cardReadings;
   SensorNodeSnapshot? sqlCardReadings;
-  SMAlerts? alertsStreamData;
+  SensorAlerts? alertsStreamData;
 
   Color? tempColor;
   Color? moistureColor;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:smmic/components/bottomnavbar/bottom_nav_bar.dart';
 import 'package:smmic/constants/api.dart';
-import 'package:smmic/preload/preloaddevices.dart';
 import 'package:smmic/providers/connections_provider.dart';
 import 'package:smmic/providers/device_settings_provider.dart';
 import 'package:smmic/pages/login.dart';
@@ -80,7 +79,7 @@ class _AuthGateState extends State<AuthGate> {
     return true;
   }
 
-  Future<void> loadProviders({
+  Future<void> _loadProviders({
     required BuildContext context,
   }) async {
     // initiate user data when logged in
@@ -88,7 +87,7 @@ class _AuthGateState extends State<AuthGate> {
     context.read<UserDataProvider>().init();
     context.read<AuthProvider>().init();
     context.read<MqttProvider>().registerContext(context: context);
-    await Future.delayed(const Duration(seconds: 5));
+    await Future.delayed(const Duration(seconds: 2));
     return;
   }
 
@@ -118,14 +117,15 @@ class _AuthGateState extends State<AuthGate> {
             }
 
             return FutureBuilder(
-                future: loadProviders(context: context),
+                future: _loadProviders(context: context),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
-                    return Center(child: CircularProgressIndicator());
+                    // TODO   add loading screen
+                    return const Center(child: CircularProgressIndicator());
                   }
 
                   context.read<DevicesProvider>().init(
-                      connectivity: context.watch<ConnectionProvider>().connectionStatus
+                      connectivity: context.read<ConnectionProvider>().connectionStatus
                   );
 
                   _apiRequest.connectSeReadingsChannel(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -128,11 +128,12 @@ class _AuthGateState extends State<AuthGate> {
                       connectivity: context.read<ConnectionProvider>().connectionStatus
                   );
 
-                  _apiRequest.connectSeReadingsChannel(
+                  _apiRequest.initSeReadingsWSChannel(
                       route: _apiRoutes.seReadingsWs,
                       context: context
                   );
-                  _apiRequest.connectAlertsChannel(
+
+                  _apiRequest.initSeAlertsWSChannel(
                       route: _apiRoutes.seAlertsWs,
                       context: context
                   );

--- a/lib/models/device_data_models.dart
+++ b/lib/models/device_data_models.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-enum SinkNodeKeys{
+enum SinkNodeKeys {
   deviceID('device_id'),
   deviceName('name'),
   latitude('latitude'),
@@ -11,7 +11,7 @@ enum SinkNodeKeys{
   const SinkNodeKeys(this.key);
 }
 
-enum SensorNodeKeys{
+enum SensorNodeKeys {
   deviceID('device_id'),
   deviceName('name'),
   latitude('latitude'),
@@ -20,6 +20,28 @@ enum SensorNodeKeys{
 
   final String key;
   const SensorNodeKeys(this.key);
+}
+
+enum SMSensorSnapshotKeys {
+  deviceID('device_id'),
+  timestamp('timestamp'),
+  soilMoisture('soil_moisture'),
+  temperature('temperature'),
+  humidity('humidity'),
+  batteryLevel('battery_level');
+
+  final String key;
+  const SMSensorSnapshotKeys(this.key);
+}
+
+enum SensorAlertKeys {
+  deviceID('device_id'),
+  timestamp('timestamp'),
+  alertCode('alert_code'),
+  data('data');
+  
+  final String key;
+  const SensorAlertKeys(this.key);
 }
 
 class Device {
@@ -105,14 +127,27 @@ class SensorNodeSnapshot {
   });
 
   factory SensorNodeSnapshot.fromJSON(Map<String, dynamic> data) {
+    // the data contains a 'data' key, it is an alert message
     final dataValues = data.containsKey('data') ? data['data'] : data;
     return SensorNodeSnapshot._internal(
-      deviceID: data['device_id'],
-      timestamp: DateTime.parse(data['timestamp']),
-      soilMoisture: double.parse(dataValues['soil_moisture'].toString()),
-      temperature: double.parse(dataValues['temperature'].toString()),
-      humidity: double.parse(dataValues['humidity'].toString()),
-      batteryLevel: double.parse(dataValues['battery_level'].toString()),
+      deviceID: data[SMSensorSnapshotKeys.deviceID.key],
+      timestamp: DateTime.parse(data[SMSensorSnapshotKeys.timestamp.key]),
+      soilMoisture: double.parse(
+          dataValues[SMSensorSnapshotKeys.soilMoisture.key]
+              .toString()
+      ),
+      temperature: double.parse(
+          dataValues[SMSensorSnapshotKeys.temperature.key]
+              .toString()
+      ),
+      humidity: double.parse(
+          dataValues[SMSensorSnapshotKeys.humidity.key]
+              .toString()
+      ),
+      batteryLevel: double.parse(
+          dataValues[SMSensorSnapshotKeys.batteryLevel.key]
+              .toString()
+      ),
     );
   }
 
@@ -133,6 +168,7 @@ class SensorNodeSnapshot {
     if (data is Map<String, dynamic>) {
       // TODO: verify keys first
       finalSnapshot = SensorNodeSnapshot.fromJSON(data);
+
     } else if (data is String) {
       // assuming that if the reading variable is a string, it is an mqtt payload
       Map<String, dynamic> fromStringMap = {};
@@ -159,18 +195,19 @@ class SensorNodeSnapshot {
 
     } else if (data is SensorNodeSnapshot) {
       finalSnapshot = data;
+
     }
 
     return finalSnapshot;
   }
 
   Map<String,dynamic> toJson() => {
-    'device_id' : deviceID,
-    'timestamp' : timestamp.toIso8601String(),
-    'soil_moisture' : soilMoisture,
-    'temperature' : temperature,
-    'humidity' : humidity,
-    'battery_level': batteryLevel
+    SMSensorSnapshotKeys.deviceID.key : deviceID,
+    SMSensorSnapshotKeys.timestamp.key : timestamp.toIso8601String(),
+    SMSensorSnapshotKeys.soilMoisture.key : soilMoisture,
+    SMSensorSnapshotKeys.temperature.key : temperature,
+    SMSensorSnapshotKeys.humidity.key : humidity,
+    SMSensorSnapshotKeys.batteryLevel.key: batteryLevel
   };
 
   @override
@@ -180,33 +217,33 @@ class SensorNodeSnapshot {
   }
 }
 
-class SMAlerts {
+class SensorAlerts {
   final String deviceID;
   final DateTime timestamp;
-  final int alerts;
+  final int alertCode;
   final Map<String,dynamic> data;
 
-  SMAlerts._internal({
+  SensorAlerts._internal({
     required this.deviceID,
     required this.timestamp,
-    required this.alerts,
+    required this.alertCode,
     required this.data
   });
 
-  factory SMAlerts.fromJSON(Map<String,dynamic> data){
-    return SMAlerts._internal(
-        deviceID: data['device_id'],
-        timestamp: DateTime.parse(data['timestamp']),
-        alerts: data['alert_code'],
-        data: data['data']
+  factory SensorAlerts.fromJSON(Map<String,dynamic> data){
+    return SensorAlerts._internal(
+        deviceID: data[SensorAlertKeys.deviceID.key],
+        timestamp: DateTime.parse(data[SensorAlertKeys.timestamp.key]),
+        alertCode: data[SensorAlertKeys.alertCode.key],
+        data: data[SensorAlertKeys.data.key]
     );
   }
 
   Map<String,dynamic> toJson() => {
-    "device_id" : deviceID,
-    "timestamp" : timestamp.toIso8601String(),
-    "alerts" : alerts,
-    "data" : data,
+    SensorAlertKeys.deviceID.key : deviceID,
+    SensorAlertKeys.timestamp.key : timestamp.toIso8601String(),
+    SensorAlertKeys.alertCode.key : alertCode,
+    SensorAlertKeys.data.key : data,
   };
 }
 

--- a/lib/pages/accountinfo.dart
+++ b/lib/pages/accountinfo.dart
@@ -103,7 +103,7 @@ class _ManageAccount extends State<ManageAccount> {
                                 context.read<AuthProvider>().accessData;
                             if (_userAccess == null) {
                               context.read<AuthProvider>().accessStatus ==
-                                  TokenStatus.forceLogin;
+                                  TokenStatus.invalid;
                               _globalNavigator.forceLoginDialog();
                             } else {
                               Map<String, dynamic> uData = {

--- a/lib/pages/devices.dart
+++ b/lib/pages/devices.dart
@@ -1,23 +1,13 @@
-import 'dart:async';
-
-import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:smmic/components/devices/cards/sensor_node_card.dart';
 import 'package:smmic/components/devices/cards/sink_node_card.dart';
 import 'package:smmic/components/devices/bottom_drawer.dart';
 import 'package:smmic/models/device_data_models.dart';
-import 'package:smmic/pages/dashboard.dart';
-import 'package:smmic/pages/devices_subpages/sensor_node_subpage.dart';
 import 'package:smmic/providers/device_settings_provider.dart';
 import 'package:smmic/providers/devices_provider.dart';
 import 'package:smmic/providers/theme_provider.dart';
-import 'package:smmic/services/devices_services.dart';
-import 'package:smmic/services/user_data_services.dart';
-import 'package:smmic/sqlitedb/db.dart';
 import 'package:smmic/utils/logs.dart';
-import '../constants/api.dart';
-import '../utils/api.dart';
 
 class Devices extends StatefulWidget {
   const Devices({super.key});

--- a/lib/pages/devices.dart
+++ b/lib/pages/devices.dart
@@ -102,7 +102,7 @@ class _Devices extends State<Devices> {
     WidgetsFlutterBinding.ensureInitialized();
     if (data is SensorNodeSnapshot) {
       context.read<DevicesProvider>().setNewSensorSnapshot(data);
-    } else if (data is SMAlerts) {
+    } else if (data is SensorAlerts) {
       // TODO: handle from alerts
     } else if (data is String) {
       context.read<DevicesProvider>().setNewSensorSnapshot(data);

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -4,6 +4,7 @@ import 'package:jwt_decode/jwt_decode.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smmic/models/auth_models.dart';
 import 'package:flutter/material.dart';
+import 'package:smmic/models/user_data_model.dart';
 import 'package:smmic/utils/auth_utils.dart';
 import 'package:smmic/utils/datetime_formatting.dart';
 import 'package:smmic/utils/global_navigator.dart';
@@ -17,7 +18,6 @@ enum TokenStatus {
   invalid, /// Invalid token
   expired, /// Expired token
   unverified, /// Cannot verify
-  forceLogin /// Force re log in
 }
 
 ///Authentication Provider
@@ -29,66 +29,80 @@ class AuthProvider extends ChangeNotifier {
   final GlobalNavigator _globalNavigator = locator<GlobalNavigator>();
   final Logs _logs = Logs(tag: 'AuthProvider()');
 
-  ///Returns the access data
+  ///Returns the access token data as a `UserAccess` object
   UserAccess? _accessData;
   UserAccess? get accessData => _accessData;
 
-  ///Returns the access status
+  ///Returns the status of the access token
   TokenStatus? _accessStatus;
   TokenStatus? get accessStatus => _accessStatus;
 
-  /// Initializes AuthProvider() using tokens from the SharedPreferences, performs verification on tokens
+  /// Returns the status of the refresh token
+  TokenStatus? _refreshStatus;
+  TokenStatus? get refreshStatus => _refreshStatus;
+
   Future<void> init() async {
-    _logs.info2(message: 'init() executing');
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
-    //String? login = await _sharedPrefsUtils.getLogin();
-    if(!sharedPreferences.containsKey('login')){
-      _logs.info(message: 'no login key found, exiting');
+
+    if (!sharedPreferences.containsKey('login')){
       return;
     }
-    Map<String, dynamic> tokens = await _sharedPrefsUtils.getTokens();
 
-    //refresh token status check
-    _logs.info(message: 'AuthProvider() verifying refreshToken');
-    TokenStatus refreshStatus = await _authUtils.verifyToken(token: tokens['refresh'], refresh: true);
+    // acquire keys first
+    // check token status of refresh token
+    // if refresh token is good, proceed to check access token
+    Map<String, dynamic> tokens = await _sharedPrefsUtils.getTokens(
+        sharedPrefsInstance: sharedPreferences
+    );
+    String? refreshToken = tokens['refresh'];
+    String? accessToken = tokens['access'];
 
-    //if refresh status check fails, verifyToken will return a TokenStatus.forceLogin and the forceLoginDialog is executed
-    if(refreshStatus == TokenStatus.forceLogin){
-      _accessData = null;
-      _accessStatus = TokenStatus.forceLogin;
+    _refreshStatus = await _authUtils.verifyToken(
+      token: refreshToken,
+      refresh: true
+    );
+
+    if (_refreshStatus == TokenStatus.invalid) {
       _globalNavigator.forceLoginDialog();
-      notifyListeners();
-      _logs.warning(message: 'forceLoginDialog() executed on .init()');
       return;
+    } else if (_refreshStatus == TokenStatus.expired) {
+      _globalNavigator.forceLoginDialog();
+      return;
+    } else if (_refreshStatus == TokenStatus.unverified) {
+      // TODO handle unverified refresh token status
+    } else if (_refreshStatus == TokenStatus.valid) {
+      _accessStatus = await _authUtils.verifyToken(
+          token: accessToken
+      );
     }
 
-    //access token status check
-    _logs.info(message: 'AuthProvider() verifying accessToken');
-    TokenStatus accessStatus = await _authUtils.verifyToken(token: tokens['access']);
-    //if access status valid, assign values to _accessData, _accessStatus
-    if(accessStatus == TokenStatus.valid){
-      _logs.success(message: 'init() done without errors or warning');
-      Map<String, dynamic>? parsedToken = _authUtils.parseToken(token: tokens['access']);
-      _accessData = UserAccess.fromJSON(parsedToken!);
-      _accessStatus = accessStatus;
-    } else {
-      _logs.warning(message: 'access token from SharedPreferences failed AuthUtils.verifyToken() check, executing AuthUtils.refreshAccessToken()...');
-      String? newAccess = await _authUtils.refreshAccessToken(refresh: tokens['refresh']);
-      if (newAccess != null) {
-        Map<String, dynamic>? newMapped = _authUtils.parseToken(token: newAccess);
-        _accessData = UserAccess.fromJSON(newMapped!);
-        _accessStatus = await _authUtils.verifyToken(token: newAccess);
-        _logs.info(message: 'access token refreshed, .init() done');
-      } else {
-        _accessData = null;
-        //TODO: handle scenario: invalid token
-        _accessStatus = TokenStatus.invalid;
-        _logs.warning(message: 'new access token invalid or null');
+    if ([TokenStatus.invalid, TokenStatus.expired].contains(_accessStatus)) {
+      // if refresh is valid refresh access token
+      if (_refreshStatus == TokenStatus.valid) {
+        accessToken = await _authUtils.refreshAccessToken(
+            refresh: refreshToken!
+        );
+      } else if (_refreshStatus == TokenStatus.unverified) {
+        _logs.warning(message: 'refresh token unverified but access status invalid, this will be allowed for now');
       }
+    } else if (_accessStatus == TokenStatus.unverified) {
+      _logs.warning(message: 'access status unverified, this will be allowed for now');
     }
+    _accessData = UserAccess.fromJSON(
+        _authUtils.parseToken(token: accessToken)!
+    );
+    _accessStatus = TokenStatus.valid;
+
+    _sharedPrefsUtils.setTokens(
+        tokens: {
+          Tokens.refresh: refreshToken,
+          Tokens.access: accessToken
+        }
+    );
+
+    _logs.success(message: 'init() done');
 
     notifyListeners();
-    return;
   }
 
   /// Sets new access data for AuthProvider. If accessStatus is not provided, will verify token using AuthUtils.verifyToken

--- a/lib/providers/connections_provider.dart
+++ b/lib/providers/connections_provider.dart
@@ -2,28 +2,56 @@ import 'package:flutter/material.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:provider/provider.dart';
 
-class ConnectionProvider extends ChangeNotifier {
-  final Connectivity _connectivity = Connectivity();
-  late Stream<List<ConnectivityResult>> _connectivityStream;
+enum WsConnectionStatus {
+  disconnected,
+  connected
+}
 
+class ConnectionProvider extends ChangeNotifier {
+  // the current connectivity of the device
   ConnectivityResult _connectionStatus = ConnectivityResult.none; // ignore: prefer_final_fields
   ConnectivityResult get connectionStatus => _connectionStatus;
 
-  Future<void> init() async {
-    _connectivityStream = _connectivity.onConnectivityChanged;
-    _connectivityStream.listen((List<ConnectivityResult>connection) async {
+  // ignore: prefer_final_fields
+  Stream<List<ConnectivityResult>> _connectivityStream = Connectivity().onConnectivityChanged;
+  Stream<List<ConnectivityResult>> get connectivityStream => _connectivityStream;
+  void init() {
+    _connectivityStream.listen((List<ConnectivityResult> connection) {
       switch (connection[0]) {
+
         case ConnectivityResult.wifi:
           _connectionStatus = ConnectivityResult.wifi;
           break;
+
         case ConnectivityResult.mobile:
           _connectionStatus = ConnectivityResult.mobile;
           break;
+
         default:
           _connectionStatus = ConnectivityResult.none;
           break;
       }
+
       notifyListeners();
     });
   }
+
+  // sensor readings web socket connection status
+  // ignore: prefer_final_fields
+  WsConnectionStatus _seWsConnectionStatus = WsConnectionStatus.disconnected;
+  WsConnectionStatus get seReadingsWsConnectionStatus => _seWsConnectionStatus;
+  void sensorWsConnectStatus(WsConnectionStatus connectionStatus) {
+    _seWsConnectionStatus = connectionStatus;
+    notifyListeners();
+  }
+
+  // alerts web socket connection status
+  // ignore: prefer_final_fields
+  WsConnectionStatus _alertsConnectionStatus = WsConnectionStatus.disconnected;
+  WsConnectionStatus get seAlertsWsConnectionStatus => _alertsConnectionStatus;
+  void alertWsConnectStatus(WsConnectionStatus connectionStatus) {
+    _seWsConnectionStatus = connectionStatus;
+    notifyListeners();
+  }
+
 }

--- a/lib/providers/devices_provider.dart
+++ b/lib/providers/devices_provider.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:smmic/constants/api.dart';
 import 'package:smmic/models/device_data_models.dart';
@@ -53,12 +55,16 @@ class DevicesProvider extends ChangeNotifier {
 
   Map <String, Map<String,int>> _deviceAlerts = {};
 
-  Future<void> init() async {
+  Future<void> init({
+    required ConnectivityResult connectivity}) async {
+    _logs.info(message: 'init() running');
+
     // acquire user data and tokens from shared prefs
     Map<String, dynamic>? userData = await _sharedPrefsUtils.getUserData();
     Map<String, dynamic> tokens = await _sharedPrefsUtils.getTokens(access: true);
 
     if (userData == null) {
+      _logs.warning(message: '.init() -> user data null!');
       return;
     }
 

--- a/lib/providers/devices_provider.dart
+++ b/lib/providers/devices_provider.dart
@@ -10,7 +10,6 @@ import 'package:smmic/utils/api.dart';
 import 'package:smmic/utils/device_utils.dart';
 import 'package:smmic/utils/logs.dart';
 import 'package:smmic/utils/shared_prefs.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 
 class DevicesProvider extends ChangeNotifier {
   // dependencies
@@ -23,10 +22,10 @@ class DevicesProvider extends ChangeNotifier {
   final ApiRoutes _apiRoutes = ApiRoutes();
   final ApiRequest _apiRequest = ApiRequest();
 
-  // sink node map lists
+  // sink node map
   Map<String, SinkNode> _sinkNodeMap = {}; // ignore: prefer_final_fields
   Map<String, SinkNode> get sinkNodeMap => _sinkNodeMap;
-  // sensor node
+  // sensor node map
   Map<String, SensorNode> _sensorNodeMap = {}; // ignore: prefer_final_fields
   Map<String, SensorNode> get sensorNodeMap => _sensorNodeMap;
 
@@ -39,25 +38,26 @@ class DevicesProvider extends ChangeNotifier {
   Map<String, List<SensorNodeSnapshot>> get sensorNodeChartDataMap => _sensorNodeChartDataMap;
 
   // sm alerts
-  List<SMAlerts?> _smAlertsList = []; // ignore: prefer_final_fields
-  List<SMAlerts?> get smAlertsList => _smAlertsList;
+  List<SensorAlerts?> _smAlertsList = []; // ignore: prefer_final_fields
+  List<SensorAlerts?> get smAlertsList => _smAlertsList;
 
-  SMAlerts? _alertCode;
-  SMAlerts? get alertCode => _alertCode;
+  SensorAlerts? _alertCode;
+  SensorAlerts? get alertCode => _alertCode;
 
-  SMAlerts? _humidityAlert;
-  SMAlerts? _tempAlert;
-  SMAlerts? _moistureAlert;
+  SensorAlerts? _humidityAlert;
+  SensorAlerts? _tempAlert;
+  SensorAlerts? _moistureAlert;
 
-  SMAlerts? get humidityAlert => _humidityAlert;
-  SMAlerts? get tempAlert => _tempAlert;
-  SMAlerts? get moistureAlert => _moistureAlert;
+  SensorAlerts? get humidityAlert => _humidityAlert;
+  SensorAlerts? get tempAlert => _tempAlert;
+  SensorAlerts? get moistureAlert => _moistureAlert;
 
   Map <String, Map<String,int>> _deviceAlerts = {};
 
-  Future<void> init({
-    required ConnectivityResult connectivity}) async {
+  Future<void> init({required ConnectivityResult connectivity}) async {
 
+    // set device list from the shared preferences
+    // TODO: add cross checking with api to verify integrity
     await _setDeviceListFromSharedPrefs();
 
     // acquire user data and tokens from shared prefs
@@ -65,20 +65,27 @@ class DevicesProvider extends ChangeNotifier {
     Map<String, dynamic> tokens = await _sharedPrefsUtils.getTokens(access: true);
 
     if (userData == null) {
-      _logs.warning(message: '.init() -> user data null!');
+      _logs.warning(message: '.init() -> user data from shared prefs is null!');
       return;
     }
 
+    // if connection sources are available,
+    // attempt setting device list from the api
     if (connectivity != ConnectivityResult.none) {
       await _setDeviceListFromApi(userData: userData, tokens: tokens);
     }
 
-    await _loadReadingsFromSqFlite();
+    // initially, load readings from the sqlite
+    await _loadReadingsFromSqlite();
 
     notifyListeners();
+
+    // set *updated* list to shared preferences
     await _setToSharedPrefs();
   }
 
+  /// Set current SinkNode and Sensor Node *objects* map
+  /// to shared preferences as `List<String>`
   Future<bool> _setToSharedPrefs() async {
 
     List<String> sinkNodeIds = _sinkNodeMap.keys.toList();
@@ -113,8 +120,9 @@ class DevicesProvider extends ChangeNotifier {
 
     return true;
   }
-  
-  Future<bool> _loadReadingsFromSqFlite() async {
+
+  /// Load initial readings and chart data from the sqlite local storage
+  Future<bool> _loadReadingsFromSqlite() async {
     for (String seId in _sensorNodeMap.keys) {
       SensorNodeSnapshot? fromSQFLiteSnapshot = await DatabaseHelper.getAllReadings(_sensorNodeMap[seId]!.deviceID);
       if (fromSQFLiteSnapshot != null){
@@ -128,7 +136,7 @@ class DevicesProvider extends ChangeNotifier {
     return true;
   }
 
-  // set device list with data from the api
+  /// Set device list from the API
   Future<bool> _setDeviceListFromApi({
     required Map<String, dynamic> userData,
     required Map<String, dynamic> tokens}) async {
@@ -163,16 +171,28 @@ class DevicesProvider extends ChangeNotifier {
     return true;
   }
 
+  /// Set device list from share preferences
+  // TODO: add cross-checking with the API to verify integrity
   Future<bool> _setDeviceListFromSharedPrefs() async {
     List<Map<String, dynamic>> sinkList = await _sharedPrefsUtils.getSinkList();
     List<Map<String, dynamic>> sensorList = await _sharedPrefsUtils.getSensorList();
 
+    // map sink nodes to objects and set to sink node map
     for (Map<String, dynamic> sinkMap in sinkList) {
       SinkNode sinkObj = _deviceUtils.sinkNodeMapToObject(sinkMap);
       _sinkNodeMap[sinkObj.deviceID] = sinkObj;
     }
 
     for (Map<String, dynamic> sensorMap in sensorList) {
+      SinkNode? correspondingSk = _sinkNodeMap[sensorMap[SensorNodeKeys.sinkNode.key]];
+      // check existence of corresponding sink node
+      if (correspondingSk == null) {
+        _logs.warning(message: 'sensor node${sensorMap[SensorNodeKeys.deviceID.key]}'
+            'present in shared preferences, but corresponding SinkNode id does'
+            'not exist in current _sinkNodeMap!');
+        continue;
+      }
+      // map to object and set to sensor node map
       SensorNode sensorObj = _deviceUtils.sensorNodeMapToObject(
           sensorMap: sensorMap,
           sinkNodeID: sensorMap[SensorNodeKeys.sinkNode.key]
@@ -195,40 +215,13 @@ class DevicesProvider extends ChangeNotifier {
   // reading:value&
   // ...
   //
+  /// Set a new sensor snapshot from any of the following type:
+  /// `Map<String, dynamic>`, `String`, `SensorNodeSnapshot` and
+  /// update chart data.
   void setNewSensorSnapshot(var reading) {
     SensorNodeSnapshot? finalSnapshot;
 
-    if (reading is Map<String, dynamic>) {
-      // TODO: verify keys first
-      finalSnapshot = SensorNodeSnapshot.fromJSON(reading);
-    } else if (reading is String) {
-      // assuming that if the reading variable is a string, it is an mqtt payload
-      Map<String, dynamic> fromStringMap = {};
-      List<String> outerSplit = reading.split(';');
-
-      fromStringMap.addAll({
-        'device_id': outerSplit[1],
-        'timestamp': outerSplit[2],
-      });
-
-      List<String> dataSplit = outerSplit[3].split('&');
-
-      for (String keyValue in dataSplit) {
-        try {
-          List<String> x = keyValue.split(':');
-          fromStringMap.addAll({x[0]: x[1]});
-        } on FormatException catch (e) {
-          _logs.error(message: 'setNewSensorReadings() raised FormatException error -> $e}');
-          break;
-        }
-      }
-
-      // create a new sensor node snapshot object from the new string map
-      finalSnapshot = SensorNodeSnapshot.fromJSON(fromStringMap);
-
-    } else if (reading is SensorNodeSnapshot) {
-      finalSnapshot = reading;
-    }
+    finalSnapshot = SensorNodeSnapshot.dynamicSerializer(data: reading);
 
     if (finalSnapshot == null) {
       return;
@@ -236,7 +229,7 @@ class DevicesProvider extends ChangeNotifier {
 
     // set snapshot
     _sensorNodeSnapshotMap[finalSnapshot.deviceID] = finalSnapshot;
-    // set chartdata
+    // set chart data
     List<SensorNodeSnapshot>? chartDataBuffer = _sensorNodeChartDataMap[finalSnapshot.deviceID];
     if (chartDataBuffer == null) {
       chartDataBuffer = [finalSnapshot];
@@ -251,20 +244,7 @@ class DevicesProvider extends ChangeNotifier {
     return;
   }
 
-  Future<void> deviceReadings(String deviceID) async {
-    _logs.info(message: 'deviceReadings running');
-
-    final latestReading = await DatabaseHelper.getAllReadings(deviceID);
-
-    if (latestReading == null) {
-      return;
-    }
-
-    _sensorNodeSnapshotMap[latestReading.deviceID] = latestReading;
-    notifyListeners();
-  }
-
-  Future<void> sensorNodeAlerts ({required SMAlerts alertMessage}) async {
+  Future<void> sensorNodeAlerts ({required SensorAlerts alertMessage}) async {
     _logs.info(message: "sensorNodeAlerts running");
 
     List<Map<String, dynamic>>? alertDataSharedPrefs = await _sharedPrefsUtils.getAlertsData();
@@ -272,7 +252,7 @@ class DevicesProvider extends ChangeNotifier {
 
     alertDataSharedPrefs.removeWhere((alert) {
       return alert['device_id'] == alertMessage.deviceID &&
-          (int.parse(alert['alerts']) ~/ 10) == (alertMessage.alerts ~/ 10);
+          (int.parse(alert['alerts']) ~/ 10) == (alertMessage.alertCode ~/ 10);
     });
 
     alertDataSharedPrefs.add(alertMessage.toJson());
@@ -286,11 +266,11 @@ class DevicesProvider extends ChangeNotifier {
 
     _alertCode = alertMessage;
 
-    if(alertMessage.alerts >= 20 && alertMessage.alerts < 30){
+    if(alertMessage.alertCode >= 20 && alertMessage.alertCode < 30){
       _humidityAlert =  alertMessage;
-    }else if(alertMessage.alerts >= 30 && alertMessage.alerts < 40){
+    }else if(alertMessage.alertCode >= 30 && alertMessage.alertCode < 40){
       _tempAlert = alertCode;
-    }else if(alertMessage.alerts >= 40 && alertMessage.alerts < 50){
+    }else if(alertMessage.alertCode >= 40 && alertMessage.alertCode < 50){
       _moistureAlert = alertCode;
     }
 

--- a/lib/providers/devices_provider.dart
+++ b/lib/providers/devices_provider.dart
@@ -151,7 +151,6 @@ class DevicesProvider extends ChangeNotifier {
     // acquire sensor nodes and add to sensorNodeMap
     for (Map<String, dynamic> sinkMap in devices) {
       List<Map<String, dynamic>> sensorMapList = sinkMap['sensor_nodes'];
-
       for (Map<String, dynamic> sensorMap in sensorMapList) {
         SensorNode sensor = _deviceUtils.sensorNodeMapToObject(
             sensorMap: sensorMap,
@@ -167,9 +166,6 @@ class DevicesProvider extends ChangeNotifier {
   Future<bool> _setDeviceListFromSharedPrefs() async {
     List<Map<String, dynamic>> sinkList = await _sharedPrefsUtils.getSinkList();
     List<Map<String, dynamic>> sensorList = await _sharedPrefsUtils.getSensorList();
-
-    _logs.error(message: sinkList.toString());
-    _logs.error(message: sensorList.toString());
 
     for (Map<String, dynamic> sinkMap in sinkList) {
       SinkNode sinkObj = _deviceUtils.sinkNodeMapToObject(sinkMap);

--- a/lib/providers/mqtt_provider.dart
+++ b/lib/providers/mqtt_provider.dart
@@ -30,7 +30,6 @@ class MqttProvider extends ChangeNotifier {
 
   void registerContext({required BuildContext context}){
     _context = context;
-    notifyListeners();
   }
 
   /// Initializes and connects the MqttClient

--- a/lib/services/auth_services.dart
+++ b/lib/services/auth_services.dart
@@ -22,10 +22,11 @@ class AuthService {
 
   Future<void> login({required String email, required String password}) async {
     _logs.info(message: 'Log in process started');
-    final data = await _apiRequest.post(route: _apiRoutes.login, body: {
-      'email': email,
-      'password': password
-    });
+    final data = await _apiRequest.post(
+        route: _apiRoutes.login, body: {
+          'email': email,
+          'password': password
+        });
 
     if (data.containsKey('error')) {
       if (data['error'] == 400) {
@@ -34,8 +35,7 @@ class AuthService {
       //TODO: HANDLE ERROR SCENARIO
       _logs.warning(message: 'Data caught error key!');
       _logs.warning(message: data.toString());
-      _globalNavigator
-          .forceLoginDialog(); // replace with a more specific dialog
+      _globalNavigator.forceLoginDialog(); // replace with a more specific dialog
     }
 
     Map<String, dynamic> body = data['data'];

--- a/lib/sqlitedb/db.dart
+++ b/lib/sqlitedb/db.dart
@@ -80,7 +80,6 @@ class DatabaseHelper {
 
     final readings = queryResult.map((data) => SensorNodeSnapshot.fromJSON(data)).toList().reversed.toList();
 
-    Logs(tag: 'DatabaseHelper.chartReadings()').info(message: '$readings');
     return readings;
   }
 }

--- a/lib/sqlitedb/db.dart
+++ b/lib/sqlitedb/db.dart
@@ -21,16 +21,12 @@ class DatabaseHelper {
   }
 
   static Future<int> addReadings(SensorNodeSnapshot readings) async {
-    print("Add Readings Initialized");
-    print("Adding Mapped Data from Stream to SQFLITE: $readings");
     final db = await _getDB();
-    print("Added Mapped Data from Stream to SQFLITE");
     return await db.insert("SMSensorReadings", readings.toJson(),
         conflictAlgorithm: ConflictAlgorithm.replace);
   }
 
   static Future<SensorNodeSnapshot?> getAllReadings(String deviceID) async {
-    print('Readings for deviceID: $deviceID');
     final db = await _getDB();
     final List<Map<String, dynamic>> maps = await db.query("SMSensorReadings",
         where: 'device_id = ?',
@@ -38,24 +34,18 @@ class DatabaseHelper {
         orderBy: 'timestamp DESC',
         limit: 1);
 
-    print("Raw Data from SQLITe: $maps");
-
     if (maps.isEmpty) {
-      print("maps is empty");
       return null;
     }
     try {
       final snapshot = SensorNodeSnapshot.fromJSON(maps.first);
-      print("Mapped SensorNodeSnapshot: $snapshot");
       return snapshot;
     } catch (e) {
-      print("Error mapping data: $e");
       return null;
     }
   }
 
   static Future<void> readingsLimit(String deviceID) async {
-    print("readingsLimit Initialized");
     final db = await _getDB();
 
     final countResult = await db.rawQuery(
@@ -67,7 +57,6 @@ class DatabaseHelper {
     const limit = 100;
 
     if (count > limit) {
-      print("Limit Exceeded Proceed to Deleting Readings for $deviceID");
       final excess = count - limit;
 
       await db.delete("SMSensorReadings",
@@ -75,7 +64,6 @@ class DatabaseHelper {
               "device_id = ? AND timestamp IN (SELECT timestamp from SMSensorReadings WHERE device_id = ? ORDER BY timestamp ASC LIMIT ?)",
           whereArgs: [deviceID, deviceID, excess]);
     }
-    print("Limit did not exceed, go on about your usual day");
   }
   
   

--- a/lib/subcomponents/devices/device_dialog.dart
+++ b/lib/subcomponents/devices/device_dialog.dart
@@ -40,7 +40,7 @@ class DeviceDialog{
                 UserAccess? userAccess = context.read<AuthProvider>().accessData;
                 SinkNode? sinkNode = context.read<DevicesProvider>().sinkNodeMap[deviceID];
                 if(userAccess == null) {
-                  context.read<AuthProvider>().accessStatus == TokenStatus.forceLogin;
+                  context.read<AuthProvider>().accessStatus == TokenStatus.invalid;
                   _globalNavigator.forceLoginDialog();
                 }else{
                   if(sinkNode == null) {
@@ -99,7 +99,7 @@ class DeviceDialog{
                 SensorNode? sensorNode = context.read<DevicesProvider>().sensorNodeMap[deviceID];
 
                 if(userAccess == null){
-                  context.read<AuthProvider>().accessStatus == TokenStatus.forceLogin;
+                  context.read<AuthProvider>().accessStatus == TokenStatus.invalid;
                   _globalNavigator.forceLoginDialog();
                 }else{
                   if(sensorNode == null){

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
-
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/cupertino.dart';
@@ -51,7 +49,7 @@ class ApiRequest {
               body: body),
           (method2) => method2(
             Uri.parse(route),
-            headers: headers)
+            headers: headers),
       );
 
       if (res == null) {
@@ -249,7 +247,7 @@ class ApiRequest {
 
   }
 
-  /// Initialize connection with the sensor readings channel
+  /// Initialize connection with the sensor readings WebSocket
   void initSeReadingsWSChannel({required String route, required BuildContext context}) {
     // attempt connection with the websocket
     WebSocketChannel? seReadingsWebSocket = _connectChannel(route);
@@ -289,7 +287,7 @@ class ApiRequest {
     });
   }
 
-  // Initialize connection with the sensor node alert websocket channel
+  /// Initialize connection with the sensor node alert WebSocket
   void initSeAlertsWSChannel({required String route, required BuildContext context}) {
     // attempt websocket connection
     WebSocketChannel? seAlertsWebSocket = _connectChannel(route);
@@ -312,7 +310,7 @@ class ApiRequest {
       DatabaseHelper.readingsLimit(snapshotObj.deviceID);
       DatabaseHelper.addReadings(snapshotObj);
 
-      final SMAlerts alertObj = SMAlerts.fromJSON(decodedData['message']);
+      final SensorAlerts alertObj = SensorAlerts.fromJSON(decodedData['message']);
 
       // pass to stream controller
       //streamController.add(alertObj);

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -10,6 +11,7 @@ import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 import 'package:smmic/constants/api.dart';
 import 'package:smmic/models/device_data_models.dart';
+import 'package:smmic/providers/connections_provider.dart';
 import 'package:smmic/providers/devices_provider.dart';
 import 'package:smmic/sqlitedb/db.dart';
 import 'package:smmic/utils/logs.dart';
@@ -21,9 +23,12 @@ class ApiRequest {
   // dependencies / helpers
   final ApiRoutes _apiRoutes = ApiRoutes();
 
-  WebSocketChannel? _seReadingsWsChannel;
-  WebSocketChannel? _alertsWsChannel;
-
+  // connections that are used to connect to the api / mqtt network
+  final List<ConnectivityResult> _sourceConnections = [
+    ConnectivityResult.mobile,
+    ConnectivityResult.wifi
+  ];
+  
   Future<Map<String, dynamic>> _request({
     required String route,
     required Either<
@@ -166,100 +171,166 @@ class ApiRequest {
     return result;
   }
 
-  void connectSeReadingsChannel({
-    required String route,
-    required BuildContext context}) {
-
+  // abstract websocket connect function
+  // returns the websocket channel instance
+  WebSocketChannel? _connectChannel(String route) {
     WebSocketChannel? channel;
-    try{
+    try {
       channel = WebSocketChannel.connect(Uri.parse(route));
+      return channel;
     } on WebSocketChannelException catch (e) {
-      _logs.warning(message: 'connectSeReadingsChannel() called WebSocketChannelException : $route -> $e');
+      _logs.warning(message: '_connectChannel() called WebSocketChannelException : $route -> $e');
     } on Exception catch (e) {
-      _logs.warning(message: 'connectSeReadingsChannel() unhandled unexpected exception raised : $route -> $e');
+      _logs.warning(message: '_connectChannel() unhandled unexpected exception raised : $route -> $e');
     }
+    return channel;
+  }
 
-    if (channel == null) {
+  // abstract websocket connection manager
+  void _wsConnectionManager(
+      BuildContext context,
+      String route,
+      WebSocketChannel channel,
+      void Function(WebSocketChannel, BuildContext) listener) async {
+
+    WebSocketChannel wsChannel = channel;
+    listener(wsChannel, context);
+
+    // listen to the connectivity stream for updates
+    // on available connections
+    Stream<List<ConnectivityResult>> connectivityStream = context.read<ConnectionProvider>().connectivityStream;
+    connectivityStream.listen((List<ConnectivityResult> connection) {
+      // when the stream updates, check the list of connectivity result for
+      // presence of any of the source connections
+      // if it contains at least one, allow connect attempt of ws
+      bool sourceAvailable = false;
+      for (ConnectivityResult source in _sourceConnections) {
+        if (connection.contains(source)) {
+          sourceAvailable = true;
+          break;
+        }
+      }
+
+      WsConnectionStatus? connectionStatus;
+
+      if (route == _apiRoutes.seReadingsWs) {
+        connectionStatus = context.read<ConnectionProvider>().seReadingsWsConnectionStatus;
+      } else if (route == _apiRoutes.seAlertsWs) {
+        connectionStatus = context.read<ConnectionProvider>().seAlertsWsConnectionStatus;
+      }
+
+      // check the connection status
+      if (!sourceAvailable && connectionStatus == WsConnectionStatus.connected) {
+        wsChannel.sink.close();
+        return;
+      } else if (!sourceAvailable) {
+        wsChannel.sink.close();
+        return;
+      }
+
+      try{
+        wsChannel = WebSocketChannel.connect(Uri.parse(route));
+
+        if (route == _apiRoutes.seReadingsWs) {
+          context.read<ConnectionProvider>().sensorWsConnectStatus(WsConnectionStatus.connected);
+        } else if (route == _apiRoutes.seAlertsWs) {
+          context.read<ConnectionProvider>().alertWsConnectStatus(WsConnectionStatus.connected);
+        }
+
+      } on WebSocketChannelException catch (e) {
+        _logs.warning(message: 'connectSeReadingsChannel() called WebSocketChannelException : $route -> $e');
+      } on Exception catch (e) {
+        _logs.warning(message: 'connectSeReadingsChannel() unhandled unexpected exception raised : $route -> $e');
+      }
+
+      listener(wsChannel, context);
+
+    });
+
+  }
+
+  /// Initialize connection with the sensor readings channel
+  void initSeReadingsWSChannel({required String route, required BuildContext context}) {
+    // attempt connection with the websocket
+    WebSocketChannel? seReadingsWebSocket = _connectChannel(route);
+    if (seReadingsWebSocket == null) {
       return;
     }
 
-    channel.stream.listen(
-      (data) {
-        final Map<String, dynamic> decodedData = jsonDecode(data);
-        final SensorNodeSnapshot snapshotObj = SensorNodeSnapshot.fromJSON(decodedData['message']);
-
-        // store data to sqlite database
-        DatabaseHelper.readingsLimit(snapshotObj.deviceID);
-        DatabaseHelper.addReadings(snapshotObj);
-
-        // pass to stream controller
-        //streamController.add(snapshotObj);
-
-        if (context.mounted) {
-          context.read<DevicesProvider>().setNewSensorSnapshot(snapshotObj);
-        }
-      }, onError: (err) {
-        _logs.warning(message: 'connectSeReadingsChannel() error in stream.listen : $route -> $err');
-    }, onDone: () {
-      channel!.sink.close();
-    });
-
+    context.read<ConnectionProvider>().sensorWsConnectStatus(WsConnectionStatus.connected);
+    _wsConnectionManager(context, route, seReadingsWebSocket, _seReadingsWsListener);
     return;
   }
 
-  void disconnectSeReadingsWs() {
-    if (_seReadingsWsChannel != null) {
-      _seReadingsWsChannel!.sink.close();
-    }
+  // the internal websocket listener wrapper function for
+  // the sensor readings websocket
+  void _seReadingsWsListener(WebSocketChannel channel, BuildContext context) {
+    channel.stream.listen((data) {
+      final Map<String, dynamic> decodedData = jsonDecode(data);
+      final SensorNodeSnapshot snapshotObj = SensorNodeSnapshot.fromJSON(decodedData['message']);
+
+      // store data to sqlite database
+      DatabaseHelper.readingsLimit(snapshotObj.deviceID);
+      DatabaseHelper.addReadings(snapshotObj);
+
+      // pass to stream controller
+      // streamController.add(snapshotObj);
+      context.read<DevicesProvider>().setNewSensorSnapshot(snapshotObj);
+
+    }, onError: (err) {
+      channel.sink.close();
+      _logs.warning(message: '_seReadingsWsListener() error in stream.listen : $err');
+      context.read<ConnectionProvider>().sensorWsConnectStatus(WsConnectionStatus.disconnected);
+
+    }, onDone: () {
+      channel.sink.close();
+      context.read<ConnectionProvider>().sensorWsConnectStatus(WsConnectionStatus.disconnected);
+
+    });
   }
 
-  void connectAlertsChannel ({
-    required String route,
-    required BuildContext context}) {
-
-    WebSocketChannel? channel;
-    try{
-      channel = WebSocketChannel.connect(Uri.parse(route));
-    } on WebSocketChannelException catch (e) {
-      _logs.warning(message: 'connectAlertsChannel() called WebSocketChannelException : $route -> $e');
-    } on Exception catch (e) {
-      _logs.warning(message: 'connectAlertsChannel() unhandled unexpected exception raised : $route -> $e');
-    }
-
-    if (channel == null) {
+  // Initialize connection with the sensor node alert websocket channel
+  void initSeAlertsWSChannel({required String route, required BuildContext context}) {
+    // attempt websocket connection
+    WebSocketChannel? seAlertsWebSocket = _connectChannel(route);
+    if (seAlertsWebSocket == null) {
       return;
     }
 
-    channel.stream.listen(
-      (data) {
-        final Map<String, dynamic> decodedData = jsonDecode(data);
-        final SensorNodeSnapshot snapshotObj = SensorNodeSnapshot.fromJSON(decodedData['message']);
-
-        // store data to sqlite
-        DatabaseHelper.readingsLimit(snapshotObj.deviceID);
-        DatabaseHelper.addReadings(snapshotObj);
-
-        final SMAlerts alertObj = SMAlerts.fromJSON(decodedData['message']);
-
-        // pass to stream controller
-        //streamController.add(alertObj);
-
-        if (context.mounted) {
-          // TODO add alertObj context update
-          context.read<DevicesProvider>().setNewSensorSnapshot(snapshotObj);
-        }
-      }, onError: (err) {
-        _logs.warning(message: 'connectAlertsChannel() error in stream.listen : $route -> $err');
-    }, onDone: () {
-        channel!.sink.close();
-    });
-
+    context.read<ConnectionProvider>().alertWsConnectStatus(WsConnectionStatus.connected);
+    _wsConnectionManager(context, route, seAlertsWebSocket, _seAlertsWsListener);
     return;
   }
 
-  void disconnectAlertsWs() {
-    if (_alertsWsChannel != null) {
-      _alertsWsChannel!.sink.close();
-    }
+  // listener wrapper function for the sensor node alerts websocket
+  void _seAlertsWsListener(WebSocketChannel channel, BuildContext context) {
+    channel.stream.listen((data) {
+      final Map<String, dynamic> decodedData = jsonDecode(data);
+      final SensorNodeSnapshot snapshotObj = SensorNodeSnapshot.fromJSON(decodedData['message']);
+
+      // store data to sqlite
+      DatabaseHelper.readingsLimit(snapshotObj.deviceID);
+      DatabaseHelper.addReadings(snapshotObj);
+
+      final SMAlerts alertObj = SMAlerts.fromJSON(decodedData['message']);
+
+      // pass to stream controller
+      //streamController.add(alertObj);
+
+      context.read<DevicesProvider>().setNewSensorSnapshot(snapshotObj);
+
+    }, onError: (err) {
+      channel.sink.close();
+      _logs.warning(message: '_seAlertsWsListener() error in stream.listen : $err');
+      context.read<ConnectionProvider>()
+          .alertWsConnectStatus(WsConnectionStatus.disconnected);
+
+    }, onDone: () {
+      channel.sink.close();
+      context.read<ConnectionProvider>()
+          .alertWsConnectStatus(WsConnectionStatus.disconnected);
+
+    });
   }
+
 }

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -61,12 +61,18 @@ class ApiRequest {
         case (500):
           _logs.error(message:'post() $route, returned with error $statusCode');
           finalRes.addAll({'error' : statusCode});
+          break;
+
         case (400):
           _logs.warning(message:'post() $route, returned with error $statusCode');
           finalRes.addAll({'error' : statusCode});
+          break;
+
         case (401):
           _logs.warning(message:'post() $route, returned with error $statusCode');
           finalRes.addAll({'error' : statusCode});
+          break;
+
         case (200):
           _logs.success(message:'post() $route, returned with data $statusCode');
           finalRes.addAll({
@@ -74,9 +80,15 @@ class ApiRequest {
             'body': resBody,
             'data': jsonDecode(resBody)
           });
+          break;
       }
+
     } on http.ClientException catch (e) {
-      _logs.warning(message: 'post() raised ClientException -> $e');
+      _logs.warning(message: 'request() raised ClientException -> $e');
+      finalRes.addAll({
+        'error': 0
+      });
+
     } catch (e) {
       _logs.warning(message:'post() unhandled unexpected post() error (statusCode: $statusCode, body: $resBody)');
     }

--- a/lib/utils/auth_utils.dart
+++ b/lib/utils/auth_utils.dart
@@ -15,11 +15,15 @@ class AuthUtils {
   final ApiRequest _apiRequest = ApiRequest();
 
   ///Parses a JWT token and returns a map with keys: `token`, `user_id`, `token_id`, `created`, `expires`. Will return a null value of the token is null.
-  Map<String, dynamic>? parseToken({String? token}){
+  Map<String, dynamic>? parseToken({
+    String? token}){
+
     Map<String, dynamic> mapped = {};
+
     if (token == null || token == ''){
       return null;
     }
+
     Map<String, dynamic> parsed = Jwt.parseJwt(token);
     mapped.addAll({
       'token': token,
@@ -28,47 +32,54 @@ class AuthUtils {
       'created': parsed['iat'],
       'expires': parsed['exp']
     });
+
     return mapped;
   }
 
   ///Verifies token validity from api. Returns `TokenStatus` enums, useful for validating access from and to database
-  Future<TokenStatus> verifyToken({required String? token, bool refresh = false}) async {
+  Future<TokenStatus> verifyToken({
+    required String? token,
+    bool refresh = false}) async {
 
-    // if provided token is null return a forceLogin or invalid TokenStatus
+    TokenStatus finalStatus = TokenStatus.unverified;
+    // if provided token is null
+    // return forceLogin if refresh token
+    // else return invalid
     if (token == null){
-      return refresh ? TokenStatus.forceLogin : TokenStatus.invalid;
+      return TokenStatus.invalid;
     }
 
-    // parse token and check if expired
+    // check if token is expired
     Map<String, dynamic> parsed = Jwt.parseJwt(token);
     DateTime expires = _dateTimeFormatting.fromJWTSeconds(parsed['exp']);
     if (expires.compareTo(DateTime.now()) < 0) {
-      return refresh ? TokenStatus.forceLogin : TokenStatus.expired;
+      return TokenStatus.expired;
     }
 
-    final Map<String, dynamic> data = await _apiRequest.post(route: _apiRoutes.verifyToken, body: {'token': token});
+    final Map<String, dynamic> data = await _apiRequest.post(
+        route: _apiRoutes.verifyToken,
+        body: {'token': token}
+    );
 
-    //TODO: HANDLE ERROR SCENARIO
-    if(data.containsKey('error')){
-      if (data['error'] == 500){
-        return TokenStatus.unverified;
-      } else {
-        return TokenStatus.forceLogin;
-      }
-    } else {
-      return TokenStatus.valid;
+    switch (data['status_code']) {
+      case 200:
+        finalStatus = TokenStatus.valid;
+        break;
+      case 400:
+        finalStatus = TokenStatus.invalid;
+        break;
+      case 500:
+        finalStatus = TokenStatus.unverified;
+        break;
+      case 0:
+        finalStatus = TokenStatus.unverified;
+        break;
+      default:
+        finalStatus = TokenStatus.unverified;
+        break;
     }
-    // try{
-    //   final response = await http.post(Uri.parse(_apiRoutes.verifyToken), body:{'token': token});
-    //   if (response.statusCode == 400 || response.statusCode == 401) {
-    //     return refresh ? TokenStatus.forceLogin : TokenStatus.invalid;
-    //   }
-    //   if (response.statusCode == 200) {
-    //     return TokenStatus.valid;
-    //   }
-    // } catch(e) {
-    //   Exception(e);
-    // }
+
+    return finalStatus;
   }
 
   ///Refreshes access token and stores the new token in SharedPreferences. Returns null if `refresh` is invalid, expired, or does not exist.

--- a/lib/utils/device_utils.dart
+++ b/lib/utils/device_utils.dart
@@ -7,11 +7,19 @@ class DeviceUtils {
 
   /// Helper function to map a sink node map into an object
   SinkNode sinkNodeMapToObject(Map<String, dynamic> sinkMap){
-    List<Map<String, dynamic>> sensorNodes = sinkMap['sensor_nodes'];
+    var sensorNodes = sinkMap['sensor_nodes'];
     List<String> sensorNodeIDList = [];
-    for (int i = 0; i < sensorNodes.length; i++){
-      sensorNodeIDList.add((sensorNodes[i]['device_id']).toString());
+
+    if (sensorNodes is List<Map<String, dynamic>>) {
+      for (int i = 0; i < sensorNodes.length; i++){
+        sensorNodeIDList.add((sensorNodes[i]['device_id']).toString().trim());
+      }
+    } else if (sensorNodes is List<String>) {
+      for (String s in sensorNodes) {
+        sensorNodeIDList.add(s.trim());
+      }
     }
+
     Map<String, dynamic> sinkNodeMap = {
       SinkNodeKeys.deviceID.key : sinkMap[SinkNodeKeys.deviceID.key],
       SinkNodeKeys.deviceName.key : sinkMap[SinkNodeKeys.deviceName.key],
@@ -25,10 +33,10 @@ class DeviceUtils {
   /// Helper function to map a sensor node map into an object
   SensorNode sensorNodeMapToObject({required Map<String, dynamic> sensorMap, required String sinkNodeID}){
     Map<String, dynamic> sensorNodeMap = {
-      SensorNodeKeys.deviceID.key : sensorMap['device_id'],
-      SensorNodeKeys.deviceName.key: sensorMap['name'],
-      SensorNodeKeys.latitude.key : sensorMap['latitude'],
-      SensorNodeKeys.longitude.key :sensorMap['longitude'],
+      SensorNodeKeys.deviceID.key : sensorMap[SensorNodeKeys.deviceID.key],
+      SensorNodeKeys.deviceName.key: sensorMap[SensorNodeKeys.deviceName.key],
+      SensorNodeKeys.latitude.key : sensorMap[SensorNodeKeys.latitude.key],
+      SensorNodeKeys.longitude.key :sensorMap[SensorNodeKeys.sinkNode.key],
       SensorNodeKeys.sinkNode.key : sinkNodeID
     };
     return SensorNode.fromJSON(sensorNodeMap);

--- a/lib/utils/shared_prefs.dart
+++ b/lib/utils/shared_prefs.dart
@@ -55,24 +55,34 @@ class SharedPrefsUtils {
   final Logs _logs = Logs(tag: 'SharedPrefsUtils()');
 
   ///Gets `refresh` and `access` tokens from SharedPreferences. Returns both tokens by default
-  Future<Map<String, dynamic>> getTokens({bool? refresh, bool? access}) async {
+  Future<Map<String, dynamic>> getTokens({
+    bool? refresh,
+    bool? access,
+    SharedPreferences? sharedPrefsInstance}) async {
+
     Map<String, dynamic> tokens = {};
-    SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
+
+    SharedPreferences sharedPreferences = sharedPrefsInstance
+        ?? await SharedPreferences.getInstance();
+
     String? refreshToken = sharedPreferences.getString('refresh');
     String? accessToken = sharedPreferences.getString('access');
+
     if(refresh == null && access == null){
       tokens.addAll({'refresh':refreshToken, 'access':accessToken});
-      _logs.info(message: 'getTokens() refreshToken: ${refreshToken.toString().substring(0, 25)}..., accessToken: ${accessToken.toString().substring(0, 25)}...');
       return tokens;
     }
+
     if(refresh != null && refresh){
       tokens.addAll({'refresh':refreshToken});
       _logs.info(message: 'getTokens() refreshToken: ${refreshToken.toString().substring(0, 25)}...');
     }
+
     if(access != null && access){
       tokens.addAll({'access':accessToken});
       _logs.info(message: 'getTokens() accessToken: ${accessToken.toString().substring(0, 25)}...');
     }
+
     return tokens;
   }
 

--- a/lib/utils/shared_prefs.dart
+++ b/lib/utils/shared_prefs.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:jwt_decode/jwt_decode.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -182,7 +183,7 @@ class SharedPrefsUtils {
   Future<bool> setSinkList({required List<Map<String,dynamic>> sinkList}) async {
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
 
-    List <String> sinkData = sinkList.map(
+    List<String> sinkData = sinkList.map(
             (sink) => SinkNodeKeys.values.map(
                     (key) => (sink[key.key] == List<String>)
                         ? sink[key.key].join(",")


### PR DESCRIPTION
websocket connection management
- added abstracted private functions to /utils/api
- integrated websocket connection management with connectivity plus package functionalities
- implemented 'reconnect' mechanism for websockets in api.dart by adding an abstracted '_wsConnectionManager'

devices providers
- devices provider init now loads devices from the shared preferences first and the api second
- if connectivity == none, devices provider init will skip loading from api to save resources

SensorNodeSnapshot
- integrated dynamic serializer with devices provider's setNewSensorSnapshot() method
- SensorAlertKeys and SMSensorSnapshotKeys enums for key consistency

tokens
- updated some token functions

others
- added loading screen in auth gate and await to init to allow first order providers to store data to shared prefs before they are accessed by second order providers