### PR TITLE
stacked line, time ticker stream

### DIFF
--- a/lib/components/devices/cards/sensor_node_card.dart
+++ b/lib/components/devices/cards/sensor_node_card.dart
@@ -19,11 +19,13 @@ class SensorNodeCard extends StatefulWidget {
   const SensorNodeCard({
     super.key,
     required this.deviceInfo,
-    this.bottomMargin
+    this.bottomMargin,
+    required this.currentDateTime
   });
 
   final SensorNode deviceInfo;
   final double? bottomMargin;
+  final DateTime currentDateTime;
 
   @override
   State<SensorNodeCard> createState() => _SensorNodeCardState();

--- a/lib/components/devices/cards/sink_node_card.dart
+++ b/lib/components/devices/cards/sink_node_card.dart
@@ -13,12 +13,14 @@ class SinkNodeCard extends StatefulWidget {
     super.key,
     required this.deviceInfo,
     this.bottomMargin,
-    this.expanded = true
+    this.expanded = true,
+    required this.currentDateTime
   });
 
   final SinkNode deviceInfo;
   final double? bottomMargin;
   final bool expanded;
+  final DateTime currentDateTime;
 
   @override
   State<SinkNodeCard> createState() => _SinkNodeCardState();
@@ -118,26 +120,23 @@ class _SinkNodeCardState extends State<SinkNodeCard> {
         Column(
           children: [
             const SizedBox(height: 15),
-            StreamBuilder(
-                stream: _deviceUtils.timeTickerSeconds(),
-                builder: (context, snapshot) {
-                  Color iconColor = Colors.white.withOpacity(0.6);
-                  if (snapshot.hasData) {
-                    if (snapshot.data!.compareTo(
-                        lastTransmission.add(const Duration(hours: 10))) == -1) {
-                      iconColor = const Color.fromRGBO(23, 255, 50, 1);
-                    }
-                  }
-                  return SvgPicture.asset(
-                    'assets/icons/signal.svg',
-                    width: iconSize,
-                    height: iconSize,
-                    colorFilter: ColorFilter.mode(
-                        iconColor,
-                        BlendMode.srcATop
-                    ),
-                  );
+            Builder(
+              builder: (context) {
+                Color iconColor = Colors.white.withOpacity(0.6);
+                if (widget.currentDateTime.compareTo(
+                    lastTransmission.add(const Duration(hours: 10))) == -1) {
+                  iconColor = const Color.fromRGBO(23, 255, 50, 1);
                 }
+                return SvgPicture.asset(
+                  'assets/icons/signal.svg',
+                  width: iconSize,
+                  height: iconSize,
+                  colorFilter: ColorFilter.mode(
+                      iconColor,
+                      BlendMode.srcATop
+                  ),
+                );
+              },
             )
           ],
         ),
@@ -174,12 +173,11 @@ class _SinkNodeCardState extends State<SinkNodeCard> {
 
   Widget _lastTransmission({required DateTime latestTimestamp}) {
     // stream builder to get data from time ticker function
-    return StreamBuilder<DateTime>(
-        stream: _deviceUtils.timeTickerSeconds(),
-        builder: (context, snapshot) {
+    return Builder(
+        builder: (context) {
           String displayText = _deviceUtils.relativeTimeDisplay(
               latestTimestamp,
-              snapshot.data ?? DateTime.now()
+              widget.currentDateTime
           );
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/components/devices/sensor_node_subpage/sensor_node_card_expanded.dart
+++ b/lib/components/devices/sensor_node_subpage/sensor_node_card_expanded.dart
@@ -106,7 +106,7 @@ class _SensorNodeCardExpandedState extends State<SensorNodeCardExpanded> {
         child: Container(
           padding: const EdgeInsets.all(40),
           decoration: BoxDecoration(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withOpacity(0.65),
               borderRadius: BorderRadius.all(Radius.circular(25))
           ),
           child: child,

--- a/lib/components/devices/sensor_node_subpage/sensor_node_card_expanded.dart
+++ b/lib/components/devices/sensor_node_subpage/sensor_node_card_expanded.dart
@@ -17,9 +17,11 @@ class SensorNodeCardExpanded extends StatefulWidget {
   const SensorNodeCardExpanded({
     super.key,
     required this.deviceID,
+    required this.currentDateTime
   });
 
   final String deviceID;
+  final DateTime currentDateTime;
 
   @override
   State<SensorNodeCardExpanded> createState() => _SensorNodeCardExpandedState();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -138,9 +138,9 @@ class _AuthGateState extends State<AuthGate> {
       } else {
         func();
       }
-      //await Future.delayed(const Duration(seconds: 1));
+      await Future.delayed(const Duration(seconds: 1));
     }
-    //await Future.delayed(const Duration(seconds: 2));
+    await Future.delayed(const Duration(seconds: 2));
     return;
   }
 

--- a/lib/pages/dashboard.dart
+++ b/lib/pages/dashboard.dart
@@ -12,6 +12,7 @@ import 'package:smmic/providers/user_data_provider.dart';
 import 'package:smmic/subcomponents/weatherComponents/weatherWidgets.dart';
 import 'package:smmic/pages/forcastpage.dart';
 import 'package:smmic/providers/theme_provider.dart';
+import 'package:smmic/utils/device_utils.dart';
 
 class DashBoard extends StatefulWidget {
   const DashBoard({super.key});
@@ -21,6 +22,8 @@ class DashBoard extends StatefulWidget {
 }
 
 class _DashBoardState extends State<DashBoard> with TickerProviderStateMixin {
+  final DeviceUtils _deviceUtils = DeviceUtils();
+
   final ScrollController _scrollController = ScrollController();
   late AnimationController _appBarBgAnimController;
   late Animation<double> _appBarBgAnimation ;
@@ -139,11 +142,19 @@ class _DashBoardState extends State<DashBoard> with TickerProviderStateMixin {
               ),
               SingleChildScrollView(
                   controller: _scrollController,
-                  child: Column(
-                    children: [
-                      const SizedBox(height: 315),
-                      ..._buildSinkCards(context.watch<DevicesProvider>().sinkNodeMap),
-                    ],
+                  child: StreamBuilder<DateTime>(
+                      stream: _deviceUtils.timeTickerSeconds(),
+                      builder: (context, snapshot) {
+                        return Column(
+                          children: [
+                            const SizedBox(height: 315),
+                            ..._buildSinkCards(
+                                context.watch<DevicesProvider>().sinkNodeMap,
+                                snapshot.data ?? DateTime.now()
+                            ),
+                          ],
+                        );
+                      }
                   )
               )
             ],
@@ -161,7 +172,7 @@ class _DashBoardState extends State<DashBoard> with TickerProviderStateMixin {
     );
   }
 
-  List<Widget> _buildSinkCards(Map<String, SinkNode> sinkNodeMap) {
+  List<Widget> _buildSinkCards(Map<String, SinkNode> sinkNodeMap, DateTime currentDateTime) {
     return sinkNodeMap.keys.indexed.map((id) {
       return Container(
         margin: EdgeInsets.only(
@@ -170,7 +181,8 @@ class _DashBoardState extends State<DashBoard> with TickerProviderStateMixin {
                 : 15
         ),
         child: SinkNodeCard(
-            deviceInfo: sinkNodeMap[id.$2]!
+          deviceInfo: sinkNodeMap[id.$2]!,
+          currentDateTime: currentDateTime,
         ),
       );
     }).toList();

--- a/lib/pages/devices_subpages/sensor_node_subpage.dart
+++ b/lib/pages/devices_subpages/sensor_node_subpage.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:smmic/components/devices/sensor_node_subpage/stacked_line.dart';
 import 'package:smmic/components/devices/sensor_node_subpage/sensor_node_card_expanded.dart';
 import 'package:smmic/providers/theme_provider.dart';
+import 'package:smmic/utils/device_utils.dart';
 import '../../models/device_data_models.dart';
 
 class SensorNodePage extends StatefulWidget {
@@ -30,6 +31,8 @@ class SensorNodePage extends StatefulWidget {
 }
 
 class _SensorNodePageState extends State<SensorNodePage> with TickerProviderStateMixin {
+  final DeviceUtils _deviceUtils = DeviceUtils();
+
   final ScrollController _scrollController = ScrollController();
   late AnimationController _appBarBgAnimController;
   late Animation<double> _appBarBgAnimation;
@@ -91,15 +94,24 @@ class _SensorNodePageState extends State<SensorNodePage> with TickerProviderStat
               controller: _scrollController,
               child: Container(
                 margin: const EdgeInsets.symmetric(horizontal: 25),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const SizedBox(height: 120),
-                    _expandedSeCard(),
-                    const SizedBox(height: 20),
-                    StackedLineChart(deviceId: widget.deviceID),
-                    const SizedBox(height: 30)
-                  ],
+                child: StreamBuilder(
+                    stream: _deviceUtils.timeTickerSeconds(),
+                    builder: (context, snapshot) {
+                      DateTime currentDateTime = snapshot.data ?? DateTime.now();
+                      return Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const SizedBox(height: 120),
+                          _expandedSeCard(currentDateTime),
+                          const SizedBox(height: 20),
+                          StackedLineChart(
+                            deviceId: widget.deviceID,
+                            currentDateTime: currentDateTime
+                          ),
+                          const SizedBox(height: 30)
+                        ],
+                      );
+                    }
                 ),
               ),
             ),
@@ -220,9 +232,10 @@ class _SensorNodePageState extends State<SensorNodePage> with TickerProviderStat
     );
   }
 
-  Widget _expandedSeCard() {
+  Widget _expandedSeCard(DateTime currentDateTime) {
     return SensorNodeCardExpanded(
       deviceID: widget.deviceID,
+      currentDateTime: currentDateTime,
     );
   }
 

--- a/lib/providers/devices_provider.dart
+++ b/lib/providers/devices_provider.dart
@@ -75,10 +75,10 @@ class DevicesProvider extends ChangeNotifier {
 
     notifyListeners();
 
-    // if (connectivity != ConnectivityResult.none) {
-    //   _loadSinkReadingsFromApi();
-    //   _loadSensorReadingsFromApi();
-    // }
+    if (connectivity != ConnectivityResult.none) {
+      _loadSinkReadingsFromApi();
+      _loadSensorReadingsFromApi();
+    }
 
     // set *updated* list to shared preferences
     await _setToSharedPrefs();


### PR DESCRIPTION
time ticker stream
- lagging on some devices due to the time ticker stream being active on each component, updated time ticker approach so that the page itself provides the stream for each dependent instead of each component listening to individual instances of the stream

stacked line
- added focused point relativeToNow display text to show relative to now time for focused point
- update values with animation *only* when chart data list from devices provider updates
- added a following background tick lines instead of the weird static one (may degrade performance of some